### PR TITLE
Support the decompress feature in shuffle component.

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -919,6 +919,8 @@ static Status GetBodyCompression(FBB& fbb, const IpcWriteOptions& options,
       codec = flatbuf::CompressionType::LZ4_FRAME;
     } else if (options.codec->compression_type() == Compression::ZSTD) {
       codec = flatbuf::CompressionType::ZSTD;
+    } else if (options.codec->compression_type() == Compression::FASTPFOR) {
+      codec = flatbuf::CompressionType::FASTPFOR;
     } else {
       return Status::Invalid("Unsupported IPC compression codec: ",
                              options.codec->name());

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -609,6 +609,8 @@ Status GetCompression(const flatbuf::RecordBatch* batch, Compression::type* out)
       *out = Compression::LZ4_FRAME;
     } else if (compression->codec() == flatbuf::CompressionType::ZSTD) {
       *out = Compression::ZSTD;
+    } else if (compression->codec() == flatbuf::CompressionType::FASTPFOR) {
+      *out = Compression::FASTPFOR;
     } else {
       return Status::Invalid("Unsupported codec in RecordBatch::compression metadata");
     }

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -88,7 +88,7 @@ Result<Compression::type> Codec::GetCompressionType(const std::string& name) {
     return Compression::ZSTD;
   } else if (name == "bz2") {
     return Compression::BZ2;
-  } else if (name == "FASTPFOR") {
+  } else if (name == "fastpfor") {
     return Compression::FASTPFOR;
   } else {
     return Status::Invalid("Unrecognized compression type: ", name);

--- a/cpp/src/generated/Message_generated.h
+++ b/cpp/src/generated/Message_generated.h
@@ -32,22 +32,25 @@ struct MessageBuilder;
 enum class CompressionType : int8_t {
   LZ4_FRAME = 0,
   ZSTD = 1,
+  FASTPFOR = 2,
   MIN = LZ4_FRAME,
   MAX = ZSTD
 };
 
-inline const CompressionType (&EnumValuesCompressionType())[2] {
+inline const CompressionType (&EnumValuesCompressionType())[3] {
   static const CompressionType values[] = {
     CompressionType::LZ4_FRAME,
-    CompressionType::ZSTD
+    CompressionType::ZSTD,
+    CompressionType::FASTPFOR
   };
   return values;
 }
 
 inline const char * const *EnumNamesCompressionType() {
-  static const char * const names[3] = {
+  static const char * const names[4] = {
     "LZ4_FRAME",
     "ZSTD",
+    "FASTPFOR",
     nullptr
   };
   return names;

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -49,7 +49,8 @@ enum CompressionType:byte {
   LZ4_FRAME,
 
   // Zstandard
-  ZSTD
+  ZSTD,
+  FASTPFOR
 }
 
 /// Provided for forward compatibility in case we need to support different

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -47,6 +48,11 @@ public class MemoryUtil {
    * The offset of the address field with the {@link java.nio.ByteBuffer} object.
    */
   static final long BYTE_BUFFER_ADDRESS_OFFSET;
+
+  /**
+   * If the native byte order is little-endian.
+   */
+  public static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   static {
     try {

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -132,7 +132,7 @@ public class MemoryUtil {
   }
 
   /**
-   * Given a {@link ByteBuf}, gets the address the underlying memory space.
+   * Given a {@link ByteBuffer}, gets the address the underlying memory space.
    *
    * @param buf the byte buffer.
    * @return address of the underlying memory.

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -74,6 +74,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.7.1</version>
+    </dependency>
   </dependencies>
 
   <pluginRepositories>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -75,9 +75,9 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
-      <artifactId>lz4-java</artifactId>
-      <version>1.7.1</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.20</version>
     </dependency>
   </dependencies>
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionCodec.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionCodec.java
@@ -28,11 +28,11 @@ public interface CompressionCodec {
   /**
    * Compress a buffer.
    * @param allocator the allocator for allocating memory for compressed buffer.
-   * @param unCompressedBuffer the buffer to compress.
+   * @param uncompressedBuffer the buffer to compress.
    *                           Implementation of this method should take care of releasing this buffer.
    * @return the compressed buffer.
    */
-  ArrowBuf compress(BufferAllocator allocator, ArrowBuf unCompressedBuffer);
+  ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer);
 
   /**
    * Decompress a buffer.

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionUtil.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionUtil.java
@@ -53,6 +53,8 @@ public class CompressionUtil {
     switch (compressionType) {
       case NoCompressionCodec.COMPRESSION_TYPE:
         return NoCompressionCodec.INSTANCE;
+      case CompressionType.LZ4_FRAME:
+        return new Lz4CompressionCodec();
       default:
         throw new IllegalArgumentException("Compression type not supported: " + compressionType);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionUtil.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionUtil.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector.compression;
 import org.apache.arrow.flatbuf.BodyCompressionMethod;
 import org.apache.arrow.flatbuf.CompressionType;
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.message.ArrowBodyCompression;
 
 /**
@@ -72,9 +73,12 @@ public class CompressionUtil {
   /**
    * Process compression by compressing the buffer as is.
    */
-  public static void compressRawBuffer(ArrowBuf inputBuffer, ArrowBuf compressedBuffer) {
+  public static ArrowBuf compressRawBuffer(BufferAllocator allocator, ArrowBuf inputBuffer) {
+    ArrowBuf compressedBuffer = allocator.buffer(SIZE_OF_UNCOMPRESSED_LENGTH + inputBuffer.writerIndex());
     compressedBuffer.setLong(0, NO_COMPRESSION_LENGTH);
     compressedBuffer.setBytes(SIZE_OF_UNCOMPRESSED_LENGTH, inputBuffer, 0, inputBuffer.writerIndex());
+    compressedBuffer.writerIndex(SIZE_OF_UNCOMPRESSED_LENGTH + inputBuffer.writerIndex());
+    return compressedBuffer;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionUtil.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionUtil.java
@@ -19,12 +19,21 @@ package org.apache.arrow.vector.compression;
 
 import org.apache.arrow.flatbuf.BodyCompressionMethod;
 import org.apache.arrow.flatbuf.CompressionType;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.ipc.message.ArrowBodyCompression;
 
 /**
  * Utilities for data compression/decompression.
  */
 public class CompressionUtil {
+
+  static final long SIZE_OF_UNCOMPRESSED_LENGTH = 8L;
+
+  /**
+   * Special flag to indicate no compression.
+   * (e.g. when the compressed buffer has a larger size.)
+   */
+  static final long NO_COMPRESSION_LENGTH = -1L;
 
   private CompressionUtil() {
   }
@@ -58,5 +67,21 @@ public class CompressionUtil {
       default:
         throw new IllegalArgumentException("Compression type not supported: " + compressionType);
     }
+  }
+
+  /**
+   * Process compression by compressing the buffer as is.
+   */
+  public static void compressRawBuffer(ArrowBuf inputBuffer, ArrowBuf compressedBuffer) {
+    compressedBuffer.setLong(0, NO_COMPRESSION_LENGTH);
+    compressedBuffer.setBytes(SIZE_OF_UNCOMPRESSED_LENGTH, inputBuffer, 0, inputBuffer.writerIndex());
+  }
+
+  /**
+   * Process decompression by decompressing the buffer as is.
+   */
+  public static ArrowBuf decompressRawBuffer(ArrowBuf inputBuffer) {
+    return inputBuffer.slice(SIZE_OF_UNCOMPRESSED_LENGTH,
+        inputBuffer.writerIndex() - SIZE_OF_UNCOMPRESSED_LENGTH);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/Lz4CompressionCodec.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/Lz4CompressionCodec.java
@@ -49,8 +49,8 @@ public class Lz4CompressionCodec implements CompressionCodec {
   }
 
   @Override
-  public ArrowBuf compress(BufferAllocator allocator, ArrowBuf unCompressedBuffer) {
-    Preconditions.checkArgument(unCompressedBuffer.writerIndex() <= Integer.MAX_VALUE,
+  public ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
+    Preconditions.checkArgument(uncompressedBuffer.writerIndex() <= Integer.MAX_VALUE,
         "The uncompressed buffer size exceeds the integer limit");
 
     // create compressor lazily
@@ -58,27 +58,27 @@ public class Lz4CompressionCodec implements CompressionCodec {
       compressor = factory.fastCompressor();
     }
 
-    int maxCompressedLength = compressor.maxCompressedLength((int) unCompressedBuffer.writerIndex());
+    int maxCompressedLength = compressor.maxCompressedLength((int) uncompressedBuffer.writerIndex());
 
     // first 8 bytes reserved for uncompressed length, to be consistent with the
     // C++ implementation.
     ArrowBuf compressedBuffer = allocator.buffer(maxCompressedLength + SIZE_OF_MESSAGE_LENGTH);
-    long uncompressedLength = unCompressedBuffer.writerIndex();
+    long uncompressedLength = uncompressedBuffer.writerIndex();
     if (!LITTLE_ENDIAN) {
       uncompressedLength = Long.reverseBytes(uncompressedLength);
     }
     compressedBuffer.setLong(0, uncompressedLength);
 
     ByteBuffer uncompressed =
-        MemoryUtil.directBuffer(unCompressedBuffer.memoryAddress(), (int) unCompressedBuffer.writerIndex());
+        MemoryUtil.directBuffer(uncompressedBuffer.memoryAddress(), (int) uncompressedBuffer.writerIndex());
     ByteBuffer compressed =
         MemoryUtil.directBuffer(compressedBuffer.memoryAddress() + SIZE_OF_MESSAGE_LENGTH, maxCompressedLength);
 
     int compressedLength = compressor.compress(
-        uncompressed, 0, (int) unCompressedBuffer.writerIndex(), compressed, 0, maxCompressedLength);
+        uncompressed, 0, (int) uncompressedBuffer.writerIndex(), compressed, 0, maxCompressedLength);
     compressedBuffer.writerIndex(compressedLength + SIZE_OF_MESSAGE_LENGTH);
 
-    unCompressedBuffer.close();
+    uncompressedBuffer.close();
     return compressedBuffer;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/Lz4CompressionCodec.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/Lz4CompressionCodec.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.compression;
+
+import java.nio.ByteBuffer;
+
+import org.apache.arrow.flatbuf.CompressionType;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.MemoryUtil;
+import org.apache.arrow.util.Preconditions;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+/**
+ * Compression codec for the LZ4 algorithm.
+ */
+public class Lz4CompressionCodec implements CompressionCodec {
+
+  private static final long SIZE_OF_MESSAGE_LENGTH = 8L;
+
+  private final LZ4Factory factory;
+
+  private LZ4Compressor compressor;
+
+  private LZ4FastDecompressor decompressor;
+
+  public Lz4CompressionCodec() {
+    factory = LZ4Factory.fastestInstance();
+  }
+
+  @Override
+  public ArrowBuf compress(BufferAllocator allocator, ArrowBuf unCompressedBuffer) {
+    Preconditions.checkArgument(unCompressedBuffer.writerIndex() <= Integer.MAX_VALUE,
+        "The uncompressed buffer size exceeds the integer limit");
+
+    // create compressor lazily
+    if (compressor == null) {
+      compressor = factory.fastCompressor();
+    }
+
+    int maxCompressedLength = compressor.maxCompressedLength((int) unCompressedBuffer.writerIndex());
+
+    // first 8 bytes reserved for uncompressed length, to be consistent with the
+    // C++ implementation.
+    ArrowBuf compressedBuffer = allocator.buffer(maxCompressedLength + SIZE_OF_MESSAGE_LENGTH);
+    compressedBuffer.setLong(0, unCompressedBuffer.writerIndex());
+
+    ByteBuffer uncompressed =
+        MemoryUtil.directBuffer(unCompressedBuffer.memoryAddress(), (int) unCompressedBuffer.writerIndex());
+    ByteBuffer compressed =
+        MemoryUtil.directBuffer(compressedBuffer.memoryAddress() + SIZE_OF_MESSAGE_LENGTH, maxCompressedLength);
+
+    int compressedLength = compressor.compress(
+        uncompressed, 0, (int) unCompressedBuffer.writerIndex(), compressed, 0, maxCompressedLength);
+    compressedBuffer.writerIndex(compressedLength + SIZE_OF_MESSAGE_LENGTH);
+
+    unCompressedBuffer.close();
+    return compressedBuffer;
+  }
+
+  @Override
+  public ArrowBuf decompress(BufferAllocator allocator, ArrowBuf compressedBuffer) {
+    Preconditions.checkArgument(compressedBuffer.writerIndex() <= Integer.MAX_VALUE,
+        "The compressed buffer size exceeds the integer limit");
+
+    Preconditions.checkArgument(compressedBuffer.writerIndex() > SIZE_OF_MESSAGE_LENGTH,
+        "Not enough data to decompress.");
+
+    // create decompressor lazily
+    if (decompressor == null) {
+      decompressor = factory.fastDecompressor();
+    }
+
+    long decompressedLength = compressedBuffer.getLong(0);
+    ByteBuffer compressed = MemoryUtil.directBuffer(
+        compressedBuffer.memoryAddress() + SIZE_OF_MESSAGE_LENGTH, (int) compressedBuffer.writerIndex());
+
+    ArrowBuf decompressedBuffer = allocator.buffer(decompressedLength);
+    ByteBuffer decompressed = MemoryUtil.directBuffer(decompressedBuffer.memoryAddress(), (int) decompressedLength);
+
+    decompressor.decompress(compressed, decompressed);
+    decompressedBuffer.writerIndex(decompressedLength);
+
+    compressedBuffer.close();
+    return decompressedBuffer;
+  }
+
+  @Override
+  public String getCodecName() {
+    return CompressionType.name(CompressionType.LZ4_FRAME);
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/Lz4CompressionCodec.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/Lz4CompressionCodec.java
@@ -21,32 +21,26 @@ import static org.apache.arrow.memory.util.MemoryUtil.LITTLE_ENDIAN;
 import static org.apache.arrow.vector.compression.CompressionUtil.NO_COMPRESSION_LENGTH;
 import static org.apache.arrow.vector.compression.CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH;
 
-import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.apache.arrow.flatbuf.CompressionType;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.util.MemoryUtil;
 import org.apache.arrow.util.Preconditions;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
 
-import net.jpountz.lz4.LZ4Compressor;
-import net.jpountz.lz4.LZ4Factory;
-import net.jpountz.lz4.LZ4FastDecompressor;
+import io.netty.util.internal.PlatformDependent;
 
 /**
  * Compression codec for the LZ4 algorithm.
  */
 public class Lz4CompressionCodec implements CompressionCodec {
-
-  private final LZ4Factory factory;
-
-  private LZ4Compressor compressor;
-
-  private LZ4FastDecompressor decompressor;
-
-  public Lz4CompressionCodec() {
-    factory = LZ4Factory.fastestInstance();
-  }
 
   @Override
   public ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
@@ -62,37 +56,46 @@ public class Lz4CompressionCodec implements CompressionCodec {
       return compressedBuffer;
     }
 
-    // create compressor lazily
-    if (compressor == null) {
-      compressor = factory.fastCompressor();
+    try {
+      ArrowBuf compressedBuffer = doCompress(allocator, uncompressedBuffer);
+      long compressedLength = compressedBuffer.writerIndex() - SIZE_OF_UNCOMPRESSED_LENGTH;
+      if (compressedLength > uncompressedBuffer.writerIndex()) {
+        // compressed buffer is larger, send the raw buffer
+        compressedBuffer.close();
+        compressedBuffer = CompressionUtil.compressRawBuffer(allocator, uncompressedBuffer);
+      }
+
+      uncompressedBuffer.close();
+      return compressedBuffer;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private ArrowBuf doCompress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) throws IOException {
+    byte[] inBytes = new byte[(int) uncompressedBuffer.writerIndex()];
+    PlatformDependent.copyMemory(uncompressedBuffer.memoryAddress(), inBytes, 0, uncompressedBuffer.writerIndex());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (InputStream in = new ByteArrayInputStream(inBytes);
+         OutputStream out = new FramedLZ4CompressorOutputStream(baos)) {
+      IOUtils.copy(in, out);
     }
 
-    int maxCompressedLength = compressor.maxCompressedLength((int) uncompressedBuffer.writerIndex());
+    byte[] outBytes = baos.toByteArray();
 
-    // first 8 bytes reserved for uncompressed length, to be consistent with the
-    // C++ implementation.
-    ArrowBuf compressedBuffer = allocator.buffer(maxCompressedLength + SIZE_OF_UNCOMPRESSED_LENGTH);
+    ArrowBuf compressedBuffer = allocator.buffer(SIZE_OF_UNCOMPRESSED_LENGTH + outBytes.length);
+
     long uncompressedLength = uncompressedBuffer.writerIndex();
     if (!LITTLE_ENDIAN) {
       uncompressedLength = Long.reverseBytes(uncompressedLength);
     }
+    // first 8 bytes reserved for uncompressed length, to be consistent with the
+    // C++ implementation.
     compressedBuffer.setLong(0, uncompressedLength);
 
-    ByteBuffer uncompressed =
-        MemoryUtil.directBuffer(uncompressedBuffer.memoryAddress(), (int) uncompressedBuffer.writerIndex());
-    ByteBuffer compressed =
-        MemoryUtil.directBuffer(compressedBuffer.memoryAddress() + SIZE_OF_UNCOMPRESSED_LENGTH, maxCompressedLength);
-
-    long compressedLength = compressor.compress(
-        uncompressed, 0, (int) uncompressedBuffer.writerIndex(), compressed, 0, maxCompressedLength);
-    if (compressedLength > uncompressedBuffer.writerIndex()) {
-      // compressed buffer is larger, send the raw buffer
-      CompressionUtil.compressRawBuffer(uncompressedBuffer, compressedBuffer);
-      compressedLength = uncompressedBuffer.writerIndex();
-    }
-    compressedBuffer.writerIndex(compressedLength + SIZE_OF_UNCOMPRESSED_LENGTH);
-
-    uncompressedBuffer.close();
+    PlatformDependent.copyMemory(
+        outBytes, 0, compressedBuffer.memoryAddress() + SIZE_OF_UNCOMPRESSED_LENGTH, outBytes.length);
+    compressedBuffer.writerIndex(SIZE_OF_UNCOMPRESSED_LENGTH + outBytes.length);
     return compressedBuffer;
   }
 
@@ -120,22 +123,33 @@ public class Lz4CompressionCodec implements CompressionCodec {
       return CompressionUtil.decompressRawBuffer(compressedBuffer);
     }
 
-    // create decompressor lazily
-    if (decompressor == null) {
-      decompressor = factory.fastDecompressor();
+    try {
+      ArrowBuf decompressedBuffer = doDecompress(allocator, compressedBuffer);
+      compressedBuffer.close();
+      return decompressedBuffer;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private ArrowBuf doDecompress(BufferAllocator allocator, ArrowBuf compressedBuffer) throws IOException {
+    long decompressedLength = compressedBuffer.getLong(0);
+    if (!LITTLE_ENDIAN) {
+      decompressedLength = Long.reverseBytes(decompressedLength);
     }
 
-    ByteBuffer compressed = MemoryUtil.directBuffer(
-        compressedBuffer.memoryAddress() + SIZE_OF_UNCOMPRESSED_LENGTH,
-        (int) (compressedBuffer.writerIndex() - SIZE_OF_UNCOMPRESSED_LENGTH));
+    byte[] inBytes = new byte[(int) (compressedBuffer.writerIndex() - SIZE_OF_UNCOMPRESSED_LENGTH)];
+    PlatformDependent.copyMemory(
+        compressedBuffer.memoryAddress() + SIZE_OF_UNCOMPRESSED_LENGTH, inBytes, 0, inBytes.length);
+    ByteArrayOutputStream out = new ByteArrayOutputStream((int) decompressedLength);
+    try (InputStream in = new FramedLZ4CompressorInputStream(new ByteArrayInputStream(inBytes))) {
+      IOUtils.copy(in, out);
+    }
 
-    ArrowBuf decompressedBuffer = allocator.buffer(decompressedLength);
-    ByteBuffer decompressed = MemoryUtil.directBuffer(decompressedBuffer.memoryAddress(), (int) decompressedLength);
-
-    decompressor.decompress(compressed, decompressed);
+    byte[] outBytes = out.toByteArray();
+    ArrowBuf decompressedBuffer = allocator.buffer(outBytes.length);
+    PlatformDependent.copyMemory(outBytes, 0, decompressedBuffer.memoryAddress(), outBytes.length);
     decompressedBuffer.writerIndex(decompressedLength);
-
-    compressedBuffer.close();
     return decompressedBuffer;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/NoCompressionCodec.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/NoCompressionCodec.java
@@ -38,8 +38,8 @@ public class NoCompressionCodec implements CompressionCodec {
   }
 
   @Override
-  public ArrowBuf compress(BufferAllocator allocator, ArrowBuf unCompressedBuffer) {
-    return unCompressedBuffer;
+  public ArrowBuf compress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
+    return uncompressedBuffer;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
@@ -41,9 +41,9 @@ import org.apache.arrow.vector.validate.MetadataV4UnionChecker;
  */
 public class ArrowStreamReader extends ArrowReader {
 
-  private MessageChannelReader messageReader;
+  protected MessageChannelReader messageReader;
 
-  private int loadedDictionaryCount;
+  protected int loadedDictionaryCount;
 
   /**
    * Constructs a streaming reader using a MessageChannelReader. Non-blocking.
@@ -138,7 +138,7 @@ public class ArrowStreamReader extends ArrowReader {
   /**
    * When read a record batch, check whether its dictionaries are available.
    */
-  private void checkDictionaries() throws IOException {
+  protected void checkDictionaries() throws IOException {
     // if all dictionaries are loaded, return.
     if (loadedDictionaryCount == dictionaries.size()) {
       return;
@@ -177,7 +177,7 @@ public class ArrowStreamReader extends ArrowReader {
   }
 
 
-  private ArrowDictionaryBatch readDictionary(MessageResult result) throws IOException {
+  protected ArrowDictionaryBatch readDictionary(MessageResult result) throws IOException {
 
     ArrowBuf bodyBuffer = result.getBodyBuffer();
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/compression/TestCompressionCodec.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compression/TestCompressionCodec.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.compression;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test cases for {@link CompressionCodec}s.
+ */
+@RunWith(Parameterized.class)
+public class TestCompressionCodec {
+
+  private final CompressionCodec codec;
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+  }
+
+  @After
+  public void terminate() {
+    allocator.close();
+  }
+
+  public TestCompressionCodec(String name, CompressionCodec codec) {
+    this.codec = codec;
+  }
+
+  @Parameterized.Parameters(name = "codec = {0}")
+  public static Collection<Object[]> getCodecs() {
+    List<Object[]> params = new ArrayList<>();
+
+    CompressionCodec dumbCodec = NoCompressionCodec.INSTANCE;
+    params.add(new Object[] {dumbCodec.getCodecName(), dumbCodec});
+
+    CompressionCodec lz4Codec = new Lz4CompressionCodec();
+    params.add(new Object[] {lz4Codec.getCodecName(), lz4Codec});
+
+    return params;
+  }
+
+  private List<ArrowBuf> compressBuffers(List<ArrowBuf> inputBuffers) {
+    List<ArrowBuf> outputBuffers = new ArrayList<>(inputBuffers.size());
+    for (ArrowBuf buf : inputBuffers) {
+      outputBuffers.add(codec.compress(allocator, buf));
+    }
+    return outputBuffers;
+  }
+
+  private List<ArrowBuf> deCompressBuffers(List<ArrowBuf> inputBuffers) {
+    List<ArrowBuf> outputBuffers = new ArrayList<>(inputBuffers.size());
+    for (ArrowBuf buf : inputBuffers) {
+      outputBuffers.add(codec.decompress(allocator, buf));
+    }
+    return outputBuffers;
+  }
+
+  @Test
+  public void testCompressFixedWidthBuffers() throws Exception {
+    final int vecLen = 1000;
+
+    // prepare vector to compress
+    IntVector origVec = new IntVector("vec", allocator);
+    origVec.allocateNew(vecLen);
+    for (int i = 0; i < vecLen; i++) {
+      if (i % 10 == 0) {
+        origVec.setNull(i);
+      } else {
+        origVec.set(i, i);
+      }
+    }
+    origVec.setValueCount(vecLen);
+    int nullCount = origVec.getNullCount();
+
+    // compress & decompress
+    List<ArrowBuf> origBuffers = origVec.getFieldBuffers();
+    List<ArrowBuf> compressedBuffers = compressBuffers(origBuffers);
+    List<ArrowBuf> decompressedBuffers = deCompressBuffers(compressedBuffers);
+
+    assertEquals(2, decompressedBuffers.size());
+
+    // orchestrate new vector
+    IntVector newVec = new IntVector("new vec", allocator);
+    newVec.loadFieldBuffers(new ArrowFieldNode(vecLen, nullCount), decompressedBuffers);
+
+    // verify new vector
+    assertEquals(vecLen, newVec.getValueCount());
+    for (int i = 0; i < vecLen; i++) {
+      if (i % 10 == 0) {
+        assertTrue(newVec.isNull(i));
+      } else {
+        assertEquals(i, newVec.get(i));
+      }
+    }
+
+    newVec.close();
+    AutoCloseables.close(decompressedBuffers);
+  }
+
+  @Test
+  public void testCompressVariableWidthBuffers() throws Exception {
+    final int vecLen = 1000;
+
+    // prepare vector to compress
+    VarCharVector origVec = new VarCharVector("vec", allocator);
+    origVec.allocateNew();
+    for (int i = 0; i < vecLen; i++) {
+      if (i % 10 == 0) {
+        origVec.setNull(i);
+      } else {
+        origVec.setSafe(i, String.valueOf(i).getBytes());
+      }
+    }
+    origVec.setValueCount(vecLen);
+    int nullCount = origVec.getNullCount();
+
+    // compress & decompress
+    List<ArrowBuf> origBuffers = origVec.getFieldBuffers();
+    List<ArrowBuf> compressedBuffers = compressBuffers(origBuffers);
+    List<ArrowBuf> decompressedBuffers = deCompressBuffers(compressedBuffers);
+
+    assertEquals(3, decompressedBuffers.size());
+
+    // orchestrate new vector
+    VarCharVector newVec = new VarCharVector("new vec", allocator);
+    newVec.loadFieldBuffers(new ArrowFieldNode(vecLen, nullCount), decompressedBuffers);
+
+    // verify new vector
+    assertEquals(vecLen, newVec.getValueCount());
+    for (int i = 0; i < vecLen; i++) {
+      if (i % 10 == 0) {
+        assertTrue(newVec.isNull(i));
+      } else {
+        assertArrayEquals(String.valueOf(i).getBytes(), newVec.get(i));
+      }
+    }
+
+    newVec.close();
+    AutoCloseables.close(decompressedBuffers);
+  }
+}


### PR DESCRIPTION
1.  Cherry pick [ARROW#10880](https://issues.apache.org/jira/browse/ARROW-10880) to support the LZ4 decompress feature in the IPC compress/decompress framework.
2. Support Fastpfor in the IPC compress/decompress framework.
3. Disable the decompress implementation when load buffers in VectorLoader. And the native sql engine will implement the decompress function.