### PR TITLE
[POAE7-947] PreBuffer parquet row groups with CacheManager

### DIFF
--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -80,6 +80,15 @@ class ARROW_EXPORT CacheManager {
   virtual bool deleteFileRange(::arrow::io::ReadRange range) = 0;
 };
 
+class ARROW_EXPORT CacheManagerProvider {
+ public:
+  CacheManagerProvider() {};
+  virtual ~CacheManagerProvider() = default;
+  virtual std::shared_ptr<CacheManager> defaultCacheManager() = 0;
+  virtual std::shared_ptr<CacheManager> newCacheManager() = 0;
+};
+
+
 /// \brief A read cache designed to hide IO latencies when reading.
 ///
 /// To use this, you must first pass it the ranges you'll need in the future.
@@ -109,14 +118,15 @@ class ARROW_EXPORT ReadRangeCache: public std::enable_shared_from_this<ReadRange
   /// \brief Read a range previously given to Cache().
   Result<std::shared_ptr<Buffer>> Read(ReadRange range);
 
-  void setCacheManager(std::shared_ptr<CacheManager> manager);
+  void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider);
 
  protected:
   struct Impl;
   std::unique_ptr<Impl> impl_;
-  std::shared_ptr<CacheManager> cache_manager_;
+  std::shared_ptr<CacheManagerProvider> cache_manager_provider_;
 
   Result<std::shared_ptr<Buffer>> CacheRange(
+    std::shared_ptr<CacheManager> cache_manager,
     std::shared_ptr<RandomAccessFile> file,
     ReadRange range);
 

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -74,10 +74,10 @@ class ARROW_EXPORT CacheManager {
  public:
   CacheManager(){};
   virtual ~CacheManager() = default;
-  virtual bool containsColumnChunk(::arrow::io::ReadRange range) = 0;
-  virtual std::shared_ptr<Buffer> getColumnChunk(::arrow::io::ReadRange range) = 0;
-  virtual bool cacheColumnChunk(::arrow::io::ReadRange range, std::shared_ptr<Buffer> data) = 0;
-  virtual bool deleteColumnChunk(::arrow::io::ReadRange range) = 0;
+  virtual bool containsFileRange(::arrow::io::ReadRange range) = 0;
+  virtual std::shared_ptr<Buffer> getFileRange(::arrow::io::ReadRange range) = 0;
+  virtual bool cacheFileRange(::arrow::io::ReadRange range, std::shared_ptr<Buffer> data) = 0;
+  virtual bool deleteFileRange(::arrow::io::ReadRange range) = 0;
 };
 
 /// \brief A read cache designed to hide IO latencies when reading.

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -211,16 +211,16 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
     // load column chunk data with cache
     bool cache_valid = false;
-    bool cache_hit = cache_manager_->containsColumnChunk(col_range);
+    bool cache_hit = cache_manager_->containsFileRange(col_range);
 
     if (cache_hit) {
-      std::shared_ptr<Buffer> data = cache_manager_->getColumnChunk(col_range);
+      std::shared_ptr<Buffer> data = cache_manager_->getFileRange(col_range);
       if (data) {
         stream = std::make_shared<::arrow::io::BufferReader>(data);
         cache_valid = true;
       } else {
         // delete invalid cache
-        cache_manager_->deleteColumnChunk(col_range);
+        cache_manager_->deleteFileRange(col_range);
         cache_valid = false;
       }
     }
@@ -230,7 +230,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
       stream = properties_.GetStream(source_, col_range.offset, col_range.length);
 
       // cache chunk data
-      cache_manager_->cacheColumnChunk(col_range,
+      cache_manager_->cacheFileRange(col_range,
         std::dynamic_pointer_cast<::arrow::io::BufferReader>(stream)->buffer());
     }
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -83,8 +83,8 @@ std::unique_ptr<PageReader> RowGroupReader::GetColumnPageReader(int i) {
   return contents_->GetColumnPageReader(i);
 }
 
-  void RowGroupReader::setCacheManager(std::shared_ptr<CacheManager> manager) {
-    contents_->setCacheManager(manager);
+  void RowGroupReader::setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider) {
+    contents_->setCacheManagerProvider(manager_provider);
   }
 
 // Returns the rowgroup metadata
@@ -155,7 +155,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
       // segments.
       PARQUET_ASSIGN_OR_THROW(auto buffer, cached_source_->Read(col_range));
       stream = std::make_shared<::arrow::io::BufferReader>(buffer);
-    } else if (cache_manager_ && !buffered_stream) {
+    } else if (cache_manager_provider_ && !buffered_stream) {
       stream = getCachedStream(col_range);
     } else {
       stream = properties_.GetStream(source_, col_range.offset, col_range.length);
@@ -211,16 +211,17 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
     // load column chunk data with cache
     bool cache_valid = false;
-    bool cache_hit = cache_manager_->containsFileRange(col_range);
+    auto cache_manager = cache_manager_provider_->defaultCacheManager();
+    bool cache_hit = cache_manager->containsFileRange(col_range);
 
     if (cache_hit) {
-      std::shared_ptr<Buffer> data = cache_manager_->getFileRange(col_range);
+      std::shared_ptr<Buffer> data = cache_manager->getFileRange(col_range);
       if (data) {
         stream = std::make_shared<::arrow::io::BufferReader>(data);
         cache_valid = true;
       } else {
         // delete invalid cache
-        cache_manager_->deleteFileRange(col_range);
+        cache_manager->deleteFileRange(col_range);
         cache_valid = false;
       }
     }
@@ -230,15 +231,15 @@ class SerializedRowGroup : public RowGroupReader::Contents {
       stream = properties_.GetStream(source_, col_range.offset, col_range.length);
 
       // cache chunk data
-      cache_manager_->cacheFileRange(col_range,
+      cache_manager->cacheFileRange(col_range,
         std::dynamic_pointer_cast<::arrow::io::BufferReader>(stream)->buffer());
     }
 
     return stream;
   }
 
-  void setCacheManager(std::shared_ptr<CacheManager> manager) override {
-    cache_manager_ = manager;
+  void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider) override {
+    cache_manager_provider_ = manager_provider;
   }
 
  private:
@@ -252,7 +253,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
   int row_group_ordinal_;
   std::shared_ptr<InternalFileDecryptor> file_decryptor_;
 
-  std::shared_ptr<CacheManager> cache_manager_;
+  std::shared_ptr<CacheManagerProvider> cache_manager_provider_;
 };
 
 // ----------------------------------------------------------------------
@@ -286,8 +287,8 @@ class SerializedFile : public ParquetFileReader::Contents {
                                file_metadata_.get(), i, properties_, file_decryptor_));
     auto ptr = std::make_shared<RowGroupReader>(std::move(contents));
 
-    if (cache_manager_) {
-      ptr->setCacheManager(cache_manager_);
+    if (cache_manager_provider_) {
+      ptr->setCacheManagerProvider(cache_manager_provider_);
     }
 
     return ptr;
@@ -314,8 +315,8 @@ class SerializedFile : public ParquetFileReader::Contents {
     }
 
     // pre buffer with cache manager
-    if (cache_manager_) {
-      cached_source_->setCacheManager(cache_manager_);
+    if (cache_manager_provider_) {
+      cached_source_->setCacheManagerProvider(cache_manager_provider_);
     }
 
     PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
@@ -370,8 +371,8 @@ class SerializedFile : public ParquetFileReader::Contents {
     }
   }
 
-  void setCacheManager(std::shared_ptr<CacheManager> manager) override {
-    cache_manager_ = manager;
+  void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider) override {
+    cache_manager_provider_ = manager_provider;
   }
 
  private:
@@ -383,7 +384,7 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   std::shared_ptr<InternalFileDecryptor> file_decryptor_;
 
-  std::shared_ptr<CacheManager> cache_manager_;
+  std::shared_ptr<CacheManagerProvider> cache_manager_provider_;
 
   void ParseUnencryptedFileMetadata(const std::shared_ptr<Buffer>& footer_buffer,
                                     int64_t footer_read_size,
@@ -664,8 +665,8 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
   file->PreBuffer(row_groups, column_indices, ctx, options);
 }
 
-void ParquetFileReader::setCacheManager(std::shared_ptr<CacheManager> manager) {
-  contents_->setCacheManager(manager);
+void ParquetFileReader::setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider) {
+  contents_->setCacheManagerProvider(manager_provider);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -312,6 +312,12 @@ class SerializedFile : public ParquetFileReader::Contents {
             ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
       }
     }
+
+    // pre buffer with cache manager
+    if (cache_manager_) {
+      cached_source_->setCacheManager(cache_manager_);
+    }
+
     PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
   }
 

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -37,6 +37,7 @@ class RandomAccessSource;
 class RowGroupMetaData;
 
 using CacheManager = ::arrow::io::internal::CacheManager;
+using CacheManagerProvider = ::arrow::io::internal::CacheManagerProvider;
 
 class PARQUET_EXPORT RowGroupReader {
  public:
@@ -48,7 +49,7 @@ class PARQUET_EXPORT RowGroupReader {
     virtual std::unique_ptr<PageReader> GetColumnPageReader(int i) = 0;
     virtual const RowGroupMetaData* metadata() const = 0;
     virtual const ReaderProperties* properties() const = 0;
-    virtual void setCacheManager(std::shared_ptr<CacheManager> manager) = 0;
+    virtual void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider) = 0;
   };
 
   explicit RowGroupReader(std::unique_ptr<Contents> contents);
@@ -62,7 +63,7 @@ class PARQUET_EXPORT RowGroupReader {
 
   std::unique_ptr<PageReader> GetColumnPageReader(int i);
 
-  void setCacheManager(std::shared_ptr<CacheManager> manager);
+  void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider);
 
  private:
   // Holds a pointer to an instance of Contents implementation
@@ -85,7 +86,7 @@ class PARQUET_EXPORT ParquetFileReader {
     virtual void Close() = 0;
     virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
     virtual std::shared_ptr<FileMetaData> metadata() const = 0;
-    virtual void setCacheManager(std::shared_ptr<CacheManager> manager) = 0;
+    virtual void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider) = 0;
   };
 
   ParquetFileReader();
@@ -148,7 +149,7 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::AsyncContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
-  void setCacheManager(std::shared_ptr<CacheManager> manager);
+  void setCacheManagerProvider(std::shared_ptr<CacheManagerProvider> manager_provider);
  private:
   // Holds a pointer to an instance of Contents implementation
   std::unique_ptr<Contents> contents_;

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -36,15 +36,7 @@ class PageReader;
 class RandomAccessSource;
 class RowGroupMetaData;
 
-class PARQUET_EXPORT CacheManager {
- public:
-  CacheManager(){};
-  virtual ~CacheManager() = default;
-  virtual bool containsColumnChunk(::arrow::io::ReadRange range) = 0;
-  virtual std::shared_ptr<Buffer> getColumnChunk(::arrow::io::ReadRange range) = 0;
-  virtual bool cacheColumnChunk(::arrow::io::ReadRange range, std::shared_ptr<Buffer> data) = 0;
-  virtual bool deleteColumnChunk(::arrow::io::ReadRange range) = 0;
-};
+using CacheManager = ::arrow::io::internal::CacheManager;
 
 class PARQUET_EXPORT RowGroupReader {
  public:


### PR DESCRIPTION
Changes:
* Move `CacheManager` interface from `parquet` to `arrow`
* Optimize function names of  `CacheManager`
* Add `CacheManagerProvider` interface to support multi-threads cache loading
* Make `ReadRangeCache` aware of cache provided by `CacheManager` when  prebuffering data.