### PR TITLE
adding standalone libhdfs3 dir

### DIFF
--- a/cpp/src/arrow/io/hdfs_internal.cc
+++ b/cpp/src/arrow/io/hdfs_internal.cc
@@ -153,6 +153,7 @@ Result<std::vector<PlatformFilename>> get_potential_libhdfs_paths() {
   ARROW_ASSIGN_OR_RAISE(auto search_paths, MakeFilenameVector({"", "."}));
 
   // Path from environment variable
+  AppendEnvVarFilename("ARROW_LIBHDFS3_DIR", &search_paths);
   AppendEnvVarFilename("HADOOP_HOME", "lib/native", &search_paths);
   AppendEnvVarFilename("ARROW_LIBHDFS_DIR", &search_paths);
 


### PR DESCRIPTION
this patch allows to use customized libhdfs3 dir

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>