### PR TITLE
fix coredump issue when client not successfully connected but need disconnect

### DIFF
--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -36,10 +36,10 @@ public class PlasmaClient implements ObjectStoreLink {
 
   private final long conn;
 
-  private PlasmaClientException plasmaClientException = null;
+  private boolean hasConnectException = false;
 
   protected void finalize() {
-    if (plasmaClientException == null) {
+    if (!hasConnectException) {
       PlasmaClientJNI.disconnect(this.conn);
     }
   }
@@ -54,7 +54,7 @@ public class PlasmaClient implements ObjectStoreLink {
     try {
       this.conn = PlasmaClientJNI.connect(storeSocketName, managerSocketName, releaseDelay);
     } catch (PlasmaClientException e) {
-      plasmaClientException = e;
+      hasConnectException = true;
       throw e;
     }
   }

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.arrow.plasma.exceptions.DuplicateObjectException;
+import org.apache.arrow.plasma.exceptions.PlasmaClientException;
 import org.apache.arrow.plasma.exceptions.PlasmaOutOfMemoryException;
 
 /**
@@ -35,13 +36,27 @@ public class PlasmaClient implements ObjectStoreLink {
 
   private final long conn;
 
+  private PlasmaClientException plasmaClientException = null;
+
   protected void finalize() {
-    PlasmaClientJNI.disconnect(this.conn);
+    if (plasmaClientException == null) {
+      PlasmaClientJNI.disconnect(this.conn);
+    }
   }
 
-  // use plasma client to initialize the underlying jni system as well via config and config-overwrites
+  /**
+   * use plasma client to initialize the underlying jni system as well via config and config-overwrites.
+   * @param storeSocketName Socket path of Plasma server
+   * @param managerSocketName managerSocketName
+   * @param releaseDelay releaseDelay
+   */
   public PlasmaClient(String storeSocketName, String managerSocketName, int releaseDelay) {
-    this.conn = PlasmaClientJNI.connect(storeSocketName, managerSocketName, releaseDelay);
+    try {
+      this.conn = PlasmaClientJNI.connect(storeSocketName, managerSocketName, releaseDelay);
+    } catch (PlasmaClientException e) {
+      plasmaClientException = e;
+      throw e;
+    }
   }
 
   // interface methods --------------------


### PR DESCRIPTION
issue:

Core dump will happen when trying to client disconnect which actually not successfully created.