### PR TITLE
BackPort [ARROW-13572]: ORC support ,  [ARROW-13797]: column projection pushdow, and refactor some classes

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -435,8 +435,21 @@ Status ORCFileReader::Open(const std::shared_ptr<io::RandomAccessFile>& file,
   return Status::OK();
 }
 
+Result<std::unique_ptr<ORCFileReader>> ORCFileReader::Open(
+    const std::shared_ptr<io::RandomAccessFile>& file, MemoryPool* pool) {
+  auto result = std::unique_ptr<ORCFileReader>(new ORCFileReader());
+  RETURN_NOT_OK(result->impl_->Open(file, pool));
+  return std::move(result);
+}
+
 Status ORCFileReader::ReadSchema(std::shared_ptr<Schema>* out) {
   return impl_->ReadSchema(out);
+}
+
+Result<std::shared_ptr<Schema>> ORCFileReader::ReadSchema() {
+  std::shared_ptr<Schema> schema;
+  RETURN_NOT_OK(impl_->ReadSchema(&schema));
+  return schema;
 }
 
 Status ORCFileReader::Read(std::shared_ptr<Table>* out) { return impl_->Read(out); }
@@ -459,6 +472,12 @@ Status ORCFileReader::Read(const std::shared_ptr<Schema>& schema,
 
 Status ORCFileReader::ReadStripe(int64_t stripe, std::shared_ptr<RecordBatch>* out) {
   return impl_->ReadStripe(stripe, out);
+}
+
+Result<std::shared_ptr<RecordBatch>> ORCFileReader::ReadStripe(int64_t stripe) {
+  std::shared_ptr<RecordBatch> recordBatch;
+  RETURN_NOT_OK(impl_->ReadStripe(stripe, &recordBatch));
+  return recordBatch;
 }
 
 Status ORCFileReader::ReadStripe(int64_t stripe, const std::vector<int>& include_indices,

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -48,10 +48,23 @@ class ARROW_EXPORT ORCFileReader {
   static Status Open(const std::shared_ptr<io::RandomAccessFile>& file, MemoryPool* pool,
                      std::unique_ptr<ORCFileReader>* reader);
 
+  /// \brief Creates a new ORC reader
+  ///
+  /// \param[in] file the data source
+  /// \param[in] pool a MemoryPool to use for buffer allocations
+  /// \return the returned reader object
+  static Result<std::unique_ptr<ORCFileReader>> Open(
+      const std::shared_ptr<io::RandomAccessFile>& file, MemoryPool* pool);
+
   /// \brief Return the schema read from the ORC file
   ///
   /// \param[out] out the returned Schema object
   Status ReadSchema(std::shared_ptr<Schema>* out);
+
+  /// \brief Return the schema read from the ORC file
+  ///
+  /// \return the returned Schema object
+  Result<std::shared_ptr<Schema>> ReadSchema();
 
   /// \brief Read the file as a Table
   ///
@@ -91,6 +104,12 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[in] stripe the stripe index
   /// \param[out] out the returned RecordBatch
   Status ReadStripe(int64_t stripe, std::shared_ptr<RecordBatch>* out);
+
+  /// \brief Read a single stripe as a RecordBatch
+  ///
+  /// \param[in] stripe the stripe index
+  /// \return the returned RecordBatch
+  Result<std::shared_ptr<RecordBatch>> ReadStripe(int64_t stripe);
 
   /// \brief Read a single stripe as a RecordBatch
   ///

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -93,6 +93,14 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// The table will be composed of one record batch per stripe.
   ///
+  /// \param[in] include_names the selected field names to read
+  /// \return the returned Table
+  Result<std::shared_ptr<Table>> Read(const std::vector<std::string>& include_names);
+
+  /// \brief Read the file as a Table
+  ///
+  /// The table will be composed of one record batch per stripe.
+  ///
   /// \param[in] schema the Table schema
   /// \param[in] include_indices the selected field indices to read
   /// \param[out] out the returned Table
@@ -118,6 +126,14 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[out] out the returned RecordBatch
   Status ReadStripe(int64_t stripe, const std::vector<int>& include_indices,
                     std::shared_ptr<RecordBatch>* out);
+
+  /// \brief Read a single stripe as a RecordBatch
+  ///
+  /// \param[in] stripe the stripe index
+  /// \param[in] include_names the selected field names to read
+  /// \return the returned RecordBatch
+  Result<std::shared_ptr<RecordBatch>> ReadStripe(
+      int64_t stripe, const std::vector<std::string>& include_names);
 
   /// \brief Seek to designated row. Invoke NextStripeReader() after seek
   ///        will return stripe reader starting from designated row.

--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -36,6 +36,10 @@ if(ARROW_CSV)
   set(ARROW_DATASET_SRCS ${ARROW_DATASET_SRCS} file_csv.cc)
 endif()
 
+if(ARROW_ORC)
+  set(ARROW_DATASET_SRCS ${ARROW_DATASET_SRCS} file_orc.cc)
+endif()
+
 if(ARROW_PARQUET)
   set(ARROW_DATASET_LINK_STATIC ${ARROW_DATASET_LINK_STATIC} parquet_static)
   set(ARROW_DATASET_LINK_SHARED ${ARROW_DATASET_LINK_SHARED} parquet_shared)
@@ -114,6 +118,10 @@ add_arrow_dataset_test(scanner_test)
 
 if(ARROW_CSV)
   add_arrow_dataset_test(file_csv_test)
+endif()
+
+if(ARROW_ORC)
+  add_arrow_dataset_test(file_orc_test)
 endif()
 
 if(ARROW_PARQUET)

--- a/cpp/src/arrow/dataset/api.h
+++ b/cpp/src/arrow/dataset/api.h
@@ -25,5 +25,6 @@
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/file_csv.h"
 #include "arrow/dataset/file_ipc.h"
+#include "arrow/dataset/file_orc.h"
 #include "arrow/dataset/file_parquet.h"
 #include "arrow/dataset/scanner.h"

--- a/cpp/src/arrow/dataset/expression.cc
+++ b/cpp/src/arrow/dataset/expression.cc
@@ -612,6 +612,17 @@ std::vector<FieldRef> FieldsInExpression(const Expression& expr) {
   return fields;
 }
 
+bool ExpressionHasFieldRefs(const Expression& expr) {
+  if (expr.literal()) return false;
+
+  if (expr.field_ref()) return true;
+
+  for (const Expression& arg : CallNotNull(expr)->arguments) {
+    if (ExpressionHasFieldRefs(arg)) return true;
+  }
+  return false;
+}
+
 Result<Expression> FoldConstants(Expression expr) {
   return Modify(
       std::move(expr), [](Expression expr) { return expr; },

--- a/cpp/src/arrow/dataset/expression.h
+++ b/cpp/src/arrow/dataset/expression.h
@@ -159,6 +159,10 @@ Expression call(std::string function, std::vector<Expression> arguments,
 ARROW_DS_EXPORT
 std::vector<FieldRef> FieldsInExpression(const Expression&);
 
+/// Check if the expression references any fields.
+ARROW_EXPORT
+bool ExpressionHasFieldRefs(const Expression&);
+
 /// Assemble a mapping from field references to known values.
 ARROW_DS_EXPORT
 Result<std::unordered_map<FieldRef, Datum, FieldRef::Hash>> ExtractKnownFieldValues(

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -84,6 +84,13 @@ Result<std::shared_ptr<io::InputStream>> FileSource::OpenCompressed(
   return io::CompressedInputStream::Make(codec.get(), std::move(file));
 }
 
+Future<util::optional<int64_t>> FileFormat::CountRows(
+   const std::shared_ptr<FileFragment>& file, Expression predicate,
+   const std::shared_ptr<ScanOptions>& options) {
+ // Just adapt to ORC interface
+ return Future<util::optional<int64_t>>::MakeFinished(util::nullopt);
+}
+
 Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(
     FileSource source, std::shared_ptr<Schema> physical_schema) {
   return MakeFragment(std::move(source), literal(true), std::move(physical_schema));

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -180,6 +180,10 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file);
 
+  virtual Future<util::optional<int64_t>> CountRows(
+      const std::shared_ptr<FileFragment>& file, Expression predicate,
+      const std::shared_ptr<ScanOptions>& options);
+
   /// \brief Open a fragment
   virtual Result<std::shared_ptr<FileFragment>> MakeFragment(
       FileSource source, Expression partition_expression,

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/file_orc.h"
+
+#include <memory>
+
+#include "arrow/adapters/orc/adapter.h"
+#include "arrow/dataset/dataset_internal.h"
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/scanner.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/iterator.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+
+using internal::checked_pointer_cast;
+
+namespace dataset {
+
+namespace {
+
+inline Result<std::unique_ptr<arrow::adapters::orc::ORCFileReader>> OpenReader(
+    const FileSource& source,
+    const std::shared_ptr<ScanOptions>& scan_options = nullptr) {
+  ARROW_ASSIGN_OR_RAISE(auto input, source.Open());
+
+  arrow::MemoryPool* pool;
+  if (scan_options) {
+    pool = scan_options->pool;
+  } else {
+    pool = default_memory_pool();
+  }
+
+  auto reader = arrow::adapters::orc::ORCFileReader::Open(std::move(input), pool);
+  auto status = reader.status();
+  if (!status.ok()) {
+    return status.WithMessage("Could not open ORC input source '", source.path(),
+                              "': ", status.message());
+  }
+  return reader;
+}
+
+/// \brief A ScanTask backed by an ORC file.
+class OrcScanTask : public ScanTask {
+ public:
+  OrcScanTask(std::shared_ptr<FileFragment> fragment,
+              std::shared_ptr<ScanOptions> options)
+      : ScanTask(std::move(options), fragment), source_(fragment->source()) {}
+
+  Result<RecordBatchIterator> Execute() override {
+    struct Impl {
+      static Result<RecordBatchIterator> Make(const FileSource& source,
+                                              const FileFormat& format,
+                                              const ScanOptions& scan_options) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto reader, OpenReader(source, std::make_shared<ScanOptions>(scan_options)));
+        int num_stripes = reader->NumberOfStripes();
+        return RecordBatchIterator(Impl{std::move(reader), 0, num_stripes});
+      }
+
+      Result<std::shared_ptr<RecordBatch>> Next() {
+        if (i_ == num_stripes_) {
+          return nullptr;
+        }
+        std::shared_ptr<RecordBatch> batch;
+        // TODO (https://issues.apache.org/jira/browse/ARROW-13797)
+        // determine included fields from options_->MaterializedFields() to
+        // optimize the column selection (see _column_index_lookup in python
+        // orc.py for custom logic)
+        // std::vector<int> included_fields;
+        // TODO (https://issues.apache.org/jira/browse/ARROW-14153)
+        // pass scan_options_->batch_size
+        return reader_->ReadStripe(i_++);
+      }
+
+      std::unique_ptr<arrow::adapters::orc::ORCFileReader> reader_;
+      int i_;
+      int num_stripes_;
+    };
+
+    return Impl::Make(source_, *checked_pointer_cast<FileFragment>(fragment_)->format(),
+                      *options_);
+  }
+
+ private:
+  FileSource source_;
+};
+
+class OrcScanTaskIterator {
+ public:
+  static Result<ScanTaskIterator> Make(std::shared_ptr<ScanOptions> options,
+                                       std::shared_ptr<FileFragment> fragment) {
+    return ScanTaskIterator(OrcScanTaskIterator(std::move(options), std::move(fragment)));
+  }
+
+  Result<std::shared_ptr<ScanTask>> Next() {
+    if (once_) {
+      // Iteration is done.
+      return nullptr;
+    }
+
+    once_ = true;
+    return std::shared_ptr<ScanTask>(new OrcScanTask(fragment_, options_));
+  }
+
+ private:
+  OrcScanTaskIterator(std::shared_ptr<ScanOptions> options,
+                      std::shared_ptr<FileFragment> fragment)
+      : options_(std::move(options)), fragment_(std::move(fragment)) {}
+
+  bool once_ = false;
+  std::shared_ptr<ScanOptions> options_;
+  std::shared_ptr<FileFragment> fragment_;
+};
+
+}  // namespace
+
+Result<bool> OrcFileFormat::IsSupported(const FileSource& source) const {
+  RETURN_NOT_OK(source.Open().status());
+  return OpenReader(source).ok();
+}
+
+Result<std::shared_ptr<Schema>> OrcFileFormat::Inspect(const FileSource& source) const {
+  ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(source));
+  return reader->ReadSchema();
+}
+
+Result<ScanTaskIterator> OrcFileFormat::ScanFile(
+    const std::shared_ptr<ScanOptions>& options,
+    const std::shared_ptr<FileFragment>& fragment) const {
+  return OrcScanTaskIterator::Make(options, fragment);
+}
+
+Future<util::optional<int64_t>> OrcFileFormat::CountRows(
+    const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
+    const std::shared_ptr<ScanOptions>& options) {
+  if (ExpressionHasFieldRefs(predicate)) {
+    return Future<util::optional<int64_t>>::MakeFinished(util::nullopt);
+  }
+  auto self = checked_pointer_cast<OrcFileFormat>(shared_from_this());
+  return DeferNotOk(options->io_context.executor()->Submit(
+      [self, file]() -> Result<util::optional<int64_t>> {
+        ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(file->source()));
+        return reader->NumberOfRows();
+      }));
+}
+
+// //
+// // OrcFileWriter, OrcFileWriteOptions
+// //
+
+std::shared_ptr<FileWriteOptions> OrcFileFormat::DefaultWriteOptions() {
+  // TODO (https://issues.apache.org/jira/browse/ARROW-13796)
+  return nullptr;
+}
+
+Result<std::shared_ptr<FileWriter>> OrcFileFormat::MakeWriter(
+    std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
+    std::shared_ptr<FileWriteOptions> options,
+    fs::FileLocator destination_locator) const {
+  // TODO (https://issues.apache.org/jira/browse/ARROW-13796)
+  return Status::NotImplemented("ORC writer not yet implemented.");
+}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -71,7 +71,21 @@ class OrcScanTask : public ScanTask {
         ARROW_ASSIGN_OR_RAISE(
             auto reader, OpenReader(source, std::make_shared<ScanOptions>(scan_options)));
         int num_stripes = reader->NumberOfStripes();
-        return RecordBatchIterator(Impl{std::move(reader), 0, num_stripes});
+
+        auto materialized_fields = scan_options.MaterializedFields();
+        // filter out virtual columns
+        std::vector<std::string> included_fields;
+        ARROW_ASSIGN_OR_RAISE(auto schema, reader->ReadSchema());
+        for (auto name : materialized_fields) {
+          FieldRef ref(name);
+          ARROW_ASSIGN_OR_RAISE(auto match, ref.FindOneOrNone(*schema));
+          if (match.indices().empty()) continue;
+
+          included_fields.push_back(name);
+        }
+
+        return RecordBatchIterator(
+            Impl{std::move(reader), 0, num_stripes, included_fields});
       }
 
       Result<std::shared_ptr<RecordBatch>> Next() {
@@ -79,19 +93,15 @@ class OrcScanTask : public ScanTask {
           return nullptr;
         }
         std::shared_ptr<RecordBatch> batch;
-        // TODO (https://issues.apache.org/jira/browse/ARROW-13797)
-        // determine included fields from options_->MaterializedFields() to
-        // optimize the column selection (see _column_index_lookup in python
-        // orc.py for custom logic)
-        // std::vector<int> included_fields;
         // TODO (https://issues.apache.org/jira/browse/ARROW-14153)
         // pass scan_options_->batch_size
-        return reader_->ReadStripe(i_++);
+        return reader_->ReadStripe(i_++, included_fields_);
       }
 
       std::unique_ptr<arrow::adapters::orc::ORCFileReader> reader_;
       int i_;
       int num_stripes_;
+      std::vector<std::string> included_fields_;
     };
 
     return Impl::Make(source_, *checked_pointer_cast<FileFragment>(fragment_)->format(),

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -180,5 +180,12 @@ std::shared_ptr<FileWriteOptions> OrcFileFormat::DefaultWriteOptions() {
  return nullptr;
 }
 
+Result<std::shared_ptr<FileWriter>> OrcFileFormat::MakeWriter(
+  std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
+  std::shared_ptr<FileWriteOptions> options) const {
+  // TODO (https://issues.apache.org/jira/browse/ARROW-13796)
+  return Status::NotImplemented("ORC writer not yet implemented.");
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_orc.cc
+++ b/cpp/src/arrow/dataset/file_orc.cc
@@ -148,7 +148,7 @@ Result<ScanTaskIterator> OrcFileFormat::ScanFile(
 }
 
 Future<util::optional<int64_t>> OrcFileFormat::CountRows(
-    const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
+    const std::shared_ptr<FileFragment>& file, Expression predicate,
     const std::shared_ptr<ScanOptions>& options) {
   if (ExpressionHasFieldRefs(predicate)) {
     return Future<util::optional<int64_t>>::MakeFinished(util::nullopt);
@@ -166,16 +166,8 @@ Future<util::optional<int64_t>> OrcFileFormat::CountRows(
 // //
 
 std::shared_ptr<FileWriteOptions> OrcFileFormat::DefaultWriteOptions() {
-  // TODO (https://issues.apache.org/jira/browse/ARROW-13796)
-  return nullptr;
-}
-
-Result<std::shared_ptr<FileWriter>> OrcFileFormat::MakeWriter(
-    std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
-    std::shared_ptr<FileWriteOptions> options,
-    fs::FileLocator destination_locator) const {
-  // TODO (https://issues.apache.org/jira/browse/ARROW-13796)
-  return Status::NotImplemented("ORC writer not yet implemented.");
+ // TODO (https://issues.apache.org/jira/browse/ARROW-13796)
+ return nullptr;
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_orc.h
+++ b/cpp/src/arrow/dataset/file_orc.h
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This API is EXPERIMENTAL.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/type_fwd.h"
+#include "arrow/dataset/visibility.h"
+#include "arrow/io/type_fwd.h"
+#include "arrow/result.h"
+
+namespace arrow {
+namespace dataset {
+
+/// \addtogroup dataset-file-formats
+///
+/// @{
+
+constexpr char kOrcTypeName[] = "orc";
+
+/// \brief A FileFormat implementation that reads from and writes to ORC files
+class ARROW_DS_EXPORT OrcFileFormat : public FileFormat {
+ public:
+  std::string type_name() const override { return kOrcTypeName; }
+
+  bool Equals(const FileFormat& other) const override {
+    return type_name() == other.type_name();
+  }
+
+  Result<bool> IsSupported(const FileSource& source) const override;
+
+  /// \brief Return the schema of the file if possible.
+  Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
+
+  /// \brief Open a file for scanning
+  Result<ScanTaskIterator> ScanFile(
+      const std::shared_ptr<ScanOptions>& options,
+      const std::shared_ptr<FileFragment>& fragment) const override;
+
+  // TODO add async version (https://issues.apache.org/jira/browse/ARROW-13795)
+  // Result<RecordBatchGenerator> ScanBatchesAsync(
+  //     const std::shared_ptr<ScanOptions>& options,
+  //     const std::shared_ptr<FileFragment>& file) const override;
+
+  Future<util::optional<int64_t>> CountRows(
+      const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
+      const std::shared_ptr<ScanOptions>& options) override;
+
+  Result<std::shared_ptr<FileWriter>> MakeWriter(
+      std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
+      std::shared_ptr<FileWriteOptions> options,
+      fs::FileLocator destination_locator) const override;
+
+  std::shared_ptr<FileWriteOptions> DefaultWriteOptions() override;
+};
+
+/// @}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/file_orc.h
+++ b/cpp/src/arrow/dataset/file_orc.h
@@ -66,6 +66,10 @@ class ARROW_DS_EXPORT OrcFileFormat : public FileFormat {
       const std::shared_ptr<ScanOptions>& options) override;
 
   std::shared_ptr<FileWriteOptions> DefaultWriteOptions() override;
+  
+  Result<std::shared_ptr<FileWriter>> MakeWriter(
+      std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
+      std::shared_ptr<FileWriteOptions> options) const override;
 };
 
 /// @}

--- a/cpp/src/arrow/dataset/file_orc.h
+++ b/cpp/src/arrow/dataset/file_orc.h
@@ -62,13 +62,8 @@ class ARROW_DS_EXPORT OrcFileFormat : public FileFormat {
   //     const std::shared_ptr<FileFragment>& file) const override;
 
   Future<util::optional<int64_t>> CountRows(
-      const std::shared_ptr<FileFragment>& file, compute::Expression predicate,
+      const std::shared_ptr<FileFragment>& file, Expression predicate,
       const std::shared_ptr<ScanOptions>& options) override;
-
-  Result<std::shared_ptr<FileWriter>> MakeWriter(
-      std::shared_ptr<io::OutputStream> destination, std::shared_ptr<Schema> schema,
-      std::shared_ptr<FileWriteOptions> options,
-      fs::FileLocator destination_locator) const override;
 
   std::shared_ptr<FileWriteOptions> DefaultWriteOptions() override;
 };

--- a/cpp/src/arrow/dataset/file_orc_test.cc
+++ b/cpp/src/arrow/dataset/file_orc_test.cc
@@ -73,10 +73,10 @@ TEST_P(TestOrcFileFormatScan, ScanRecordBatchReader) { TestScan(); }
 TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
   TestScanWithVirtualColumn();
 }
-// TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjected) { TestScanProjected(); }
-// TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
-//   TestScanProjectedMissingCols();
-// }
+TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjected) { TestScanProjected(); }
+TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
+  TestScanProjectedMissingCols();
+}
 INSTANTIATE_TEST_SUITE_P(TestScan, TestOrcFileFormatScan,
                          ::testing::ValuesIn(TestFormatParams::Values()),
                          TestFormatParams::ToTestNameString);

--- a/cpp/src/arrow/dataset/file_orc_test.cc
+++ b/cpp/src/arrow/dataset/file_orc_test.cc
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/file_orc.h"
+
+#include <memory>
+#include <utility>
+
+#include "arrow/adapters/orc/adapter.h"
+#include "arrow/dataset/dataset_internal.h"
+#include "arrow/dataset/discovery.h"
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/partition.h"
+#include "arrow/dataset/scanner_internal.h"
+#include "arrow/dataset/test_util.h"
+#include "arrow/io/memory.h"
+#include "arrow/record_batch.h"
+#include "arrow/table.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/util.h"
+
+namespace arrow {
+namespace dataset {
+
+class OrcFormatHelper {
+ public:
+  using FormatType = OrcFileFormat;
+  static Result<std::shared_ptr<Buffer>> Write(RecordBatchReader* reader) {
+    ARROW_ASSIGN_OR_RAISE(auto sink, io::BufferOutputStream::Create());
+    ARROW_ASSIGN_OR_RAISE(auto writer, adapters::orc::ORCFileWriter::Open(sink.get()));
+    std::shared_ptr<Table> table;
+    RETURN_NOT_OK(reader->ReadAll(&table));
+    writer->Write(*table);
+    RETURN_NOT_OK(writer->Close());
+    return sink->Finish();
+  }
+
+  static std::shared_ptr<OrcFileFormat> MakeFormat() {
+    return std::make_shared<OrcFileFormat>();
+  }
+};
+
+class TestOrcFileFormat : public FileFormatFixtureMixin<OrcFormatHelper> {};
+
+// TEST_F(TestOrcFileFormat, WriteRecordBatchReader) { TestWrite(); }
+
+TEST_F(TestOrcFileFormat, InspectFailureWithRelevantError) {
+  TestInspectFailureWithRelevantError(StatusCode::IOError, "ORC");
+}
+TEST_F(TestOrcFileFormat, Inspect) { TestInspect(); }
+TEST_F(TestOrcFileFormat, IsSupported) { TestIsSupported(); }
+TEST_F(TestOrcFileFormat, CountRows) { TestCountRows(); }
+
+// TODO add TestOrcFileSystemDataset if write support is added
+
+class TestOrcFileFormatScan : public FileFormatScanMixin<OrcFormatHelper> {};
+
+TEST_P(TestOrcFileFormatScan, ScanRecordBatchReader) { TestScan(); }
+TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderWithVirtualColumn) {
+  TestScanWithVirtualColumn();
+}
+// TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjected) { TestScanProjected(); }
+// TEST_P(TestOrcFileFormatScan, ScanRecordBatchReaderProjectedMissingCols) {
+//   TestScanProjectedMissingCols();
+// }
+INSTANTIATE_TEST_SUITE_P(TestScan, TestOrcFileFormatScan,
+                         ::testing::ValuesIn(TestFormatParams::Values()),
+                         TestFormatParams::ToTestNameString);
+
+}  // namespace dataset
+}  // namespace arrow

--- a/docs/source/cpp/dataset.rst
+++ b/docs/source/cpp/dataset.rst
@@ -33,9 +33,9 @@ Tabular Datasets
 The Arrow Datasets library provides functionality to efficiently work with
 tabular, potentially larger than memory, and multi-file datasets. This includes:
 
-* A unified interface that supports different sources and file formats (currently,
-  Parquet, Feather / Arrow IPC, and CSV files) and different file systems (local,
-  cloud).
+* A unified interface that supports different sources and file formats
+  (currently, Parquet, ORC, Feather / Arrow IPC, and CSV files) and different
+  file systems (local, cloud).
 * Discovery of sources (crawling directories, handling partitioned datasets with
   various partitioning schemes, basic schema normalization, ...)
 * Optimized reading with predicate pushdown (filtering rows), projection
@@ -119,8 +119,8 @@ Reading different file formats
 The above examples use Parquet files on local disk, but the Dataset API
 provides a consistent interface across multiple file formats and filesystems.
 (See :ref:`cpp-dataset-cloud-storage` for more information on the latter.)
-Currently, Parquet, Feather / Arrow IPC, and CSV file formats are supported;
-more formats are planned in the future.
+Currently, Parquet, ORC, Feather / Arrow IPC, and CSV file formats are
+supported; more formats are planned in the future.
 
 If we save the table as Feather files instead of Parquet files:
 

--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -47,6 +47,9 @@ Classes
 
    FileFormat
    ParquetFileFormat
+   ORCFileFormat
+   IpcFileFormat
+   CsvFileFormat
    Partitioning
    PartitioningFactory
    DirectoryPartitioning

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -31,16 +31,16 @@ The ``pyarrow.dataset`` module provides functionality to efficiently work with
 tabular, potentially larger than memory, and multi-file datasets. This includes:
 
 * A unified interface that supports different sources and file formats
-  (Parquet, Feather / Arrow IPC, and CSV files) and different file systems
+  (Parquet, ORC, Feather / Arrow IPC, and CSV files) and different file systems
   (local, cloud).
 * Discovery of sources (crawling directories, handle directory-based partitioned
   datasets, basic schema normalization, ..)
 * Optimized reading with predicate pushdown (filtering rows), projection
   (selecting and deriving columns), and optionally parallel reading.
 
-Currently, only Parquet, Feather / Arrow IPC, and CSV files are supported. The
-goal is to expand this in the future to other file formats and data sources
-(e.g. database connections).
+Currently, only Parquet, ORC, Feather / Arrow IPC, and CSV files are
+supported. The goal is to expand this in the future to other file formats and
+data sources (e.g. database connections).
 
 For those familiar with the existing :class:`pyarrow.parquet.ParquetDataset` for
 reading Parquet datasets: ``pyarrow.dataset``'s goal is similar but not specific
@@ -118,8 +118,8 @@ Reading different file formats
 
 The above examples use Parquet files as dataset source but the Dataset API
 provides a consistent interface across multiple file formats and filesystems.
-Currently, Parquet, Feather / Arrow IPC, and CSV file formats are supported;
-more formats are planned in the future.
+Currently, Parquet, ORC, Feather / Arrow IPC, and CSV file formats are
+supported; more formats are planned in the future.
 
 If we save the table as Feather files instead of Parquet files:
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -486,6 +486,9 @@ endif()
 if(PYARROW_BUILD_ORC)
   # ORC
   set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} _orc)
+  if(PYARROW_BUILD_DATASET)
+    set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} _dataset_orc)
+  endif()
 endif()
 
 # Flight
@@ -604,6 +607,9 @@ endif()
 
 if(PYARROW_BUILD_DATASET)
   target_link_libraries(_dataset PRIVATE ${DATASET_LINK_LIBS})
+  if(PYARROW_BUILD_ORC)
+    target_link_libraries(_dataset_orc PRIVATE ${DATASET_LINK_LIBS})
+  endif()
 endif()
 
 if(PYARROW_BUILD_GANDIVA)

--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# cython: language_level = 3
+
+"""Dataset is currently unstable. APIs subject to change without notice."""
+
+from pyarrow.includes.common cimport *
+from pyarrow.includes.libarrow_dataset cimport *
+from pyarrow.lib cimport *
+
+
+cdef class FragmentScanOptions(_Weakrefable):
+
+    cdef:
+        shared_ptr[CFragmentScanOptions] wrapped
+
+    cdef void init(self, const shared_ptr[CFragmentScanOptions]& sp)
+
+    @staticmethod
+    cdef wrap(const shared_ptr[CFragmentScanOptions]& sp)
+
+
+cdef class FileFormat(_Weakrefable):
+
+    cdef:
+        shared_ptr[CFileFormat] wrapped
+        CFileFormat* format
+
+    cdef void init(self, const shared_ptr[CFileFormat]& sp)
+
+    @staticmethod
+    cdef wrap(const shared_ptr[CFileFormat]& sp)
+
+    cdef inline shared_ptr[CFileFormat] unwrap(self)
+
+    cdef _set_default_fragment_scan_options(self, FragmentScanOptions options)

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -52,6 +52,28 @@ def _forbid_instantiation(klass, subclasses_instead=True):
     raise TypeError(msg)
 
 
+_orc_fileformat = None
+_orc_imported = False
+
+
+def _get_orc_fileformat():
+    """
+    Import OrcFileFormat on first usage (to avoid circular import issue
+    when `pyarrow._dataset_orc` would be imported first)
+    """
+    global _orc_fileformat
+    global _orc_imported
+    if not _orc_imported:
+        try:
+            from pyarrow._dataset_orc import OrcFileFormat
+            _orc_fileformat = OrcFileFormat
+        except ImportError as e:
+            _orc_fileformat = None
+        finally:
+            _orc_imported = True
+    return _orc_fileformat
+
+
 cdef CFileSource _make_file_source(object file, FileSystem filesystem=None):
 
     cdef:
@@ -778,10 +800,6 @@ cdef class FileWriteOptions(_Weakrefable):
 
 cdef class FileFormat(_Weakrefable):
 
-    cdef:
-        shared_ptr[CFileFormat] wrapped
-        CFileFormat* format
-
     def __init__(self):
         _forbid_instantiation(self.__class__)
 
@@ -797,6 +815,7 @@ cdef class FileFormat(_Weakrefable):
             'ipc': IpcFileFormat,
             'csv': CsvFileFormat,
             'parquet': ParquetFileFormat,
+            'orc': _get_orc_fileformat(),
         }
 
         class_ = classes.get(type_name, None)
@@ -1131,9 +1150,6 @@ class RowGroupInfo:
 
 cdef class FragmentScanOptions(_Weakrefable):
     """Scan options specific to a particular fragment and scan operation."""
-
-    cdef:
-        shared_ptr[CFragmentScanOptions] wrapped
 
     def __init__(self):
         _forbid_instantiation(self.__class__)

--- a/python/pyarrow/_dataset_orc.pyx
+++ b/python/pyarrow/_dataset_orc.pyx
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# cython: language_level = 3
+
+"""Dataset support for ORC file format."""
+
+from pyarrow.lib cimport *
+from pyarrow.includes.libarrow cimport *
+from pyarrow.includes.libarrow_dataset cimport *
+
+from pyarrow._dataset cimport FileFormat
+
+
+cdef class OrcFileFormat(FileFormat):
+
+    def __init__(self):
+        self.init(shared_ptr[CFileFormat](new COrcFileFormat()))
+
+    def equals(self, OrcFileFormat other):
+        return True
+
+    @property
+    def default_extname(self):
+        return "orc"
+
+    def __reduce__(self):
+        return OrcFileFormat, tuple()

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -57,6 +57,27 @@ from pyarrow._dataset import (  # noqa
     _filesystemdataset_write,
 )
 
+_orc_available = False
+_orc_msg = (
+    "The pyarrow installation is not built with support for the ORC file "
+    "format."
+)
+
+try:
+    from pyarrow._dataset_orc import OrcFileFormat
+    _orc_available = True
+except ImportError:
+    pass
+
+
+def __getattr__(name):
+    if name == "OrcFileFormat" and not _orc_available:
+        raise ImportError(_orc_msg)
+
+    raise AttributeError(
+        "module 'pyarrow.dataset' has no attribute '{0}'".format(name)
+    )
+
 
 def field(name):
     """Reference a named column of the dataset.
@@ -252,6 +273,10 @@ def _ensure_format(obj):
         return IpcFileFormat()
     elif obj == "csv":
         return CsvFileFormat()
+    elif obj == "orc":
+        if not _orc_available:
+            raise ValueError(_orc_msg)
+        return OrcFileFormat()
     else:
         raise ValueError("format '{}' is not supported".format(obj))
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -272,6 +272,10 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             CFileFormat):
         pass
 
+    cdef cppclass COrcFileFormat "arrow::dataset::OrcFileFormat"(
+            CFileFormat):
+        pass
+
     cdef cppclass CCsvFileFormat "arrow::dataset::CsvFileFormat"(
             CFileFormat):
         CCSVParseOptions parse_options

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -606,6 +606,11 @@ def test_file_format_pickling():
             buffer_size=4096,
         )
     ]
+    try:
+        formats.append(ds.OrcFileFormat())
+    except ImportError:
+        pass
+
     for file_format in formats:
         assert pickle.loads(pickle.dumps(file_format)) == file_format
 
@@ -2363,6 +2368,67 @@ def test_ipc_format(tempdir):
         dataset = ds.dataset(path, format=format_str)
         result = dataset.to_table()
         assert result.equals(table)
+
+
+@pytest.mark.orc
+def test_orc_format(tempdir, dataset_reader):
+    from pyarrow import orc
+    table = pa.table({'a': pa.array([1, 2, 3], type="int8"),
+                      'b': pa.array([.1, .2, .3], type="float64")})
+
+    path = str(tempdir / 'test.orc')
+    orc.write_table(table, path)
+
+    dataset = ds.dataset(path, format=ds.OrcFileFormat())
+    result = dataset_reader.to_table(dataset)
+    result.validate(full=True)
+    assert result.equals(table)
+
+    dataset = ds.dataset(path, format="orc")
+    result = dataset_reader.to_table(dataset)
+    result.validate(full=True)
+    assert result.equals(table)
+
+    result = dataset_reader.to_table(dataset, columns=["b"])
+    result.validate(full=True)
+    assert result.equals(table.select(["b"]))
+
+    assert dataset_reader.count_rows(dataset) == 3
+    assert dataset_reader.count_rows(dataset, filter=ds.field("a") > 2) == 1
+
+
+@pytest.mark.orc
+def test_orc_scan_options(tempdir, dataset_reader):
+    from pyarrow import orc
+    table = pa.table({'a': pa.array([1, 2, 3], type="int8"),
+                      'b': pa.array([.1, .2, .3], type="float64")})
+
+    path = str(tempdir / 'test.orc')
+    orc.write_table(table, path)
+
+    dataset = ds.dataset(path, format="orc")
+    result = list(dataset_reader.to_batches(dataset))
+    assert len(result) == 1
+    assert result[0].num_rows == 3
+    assert result[0].equals(table.to_batches()[0])
+    # TODO batch_size is not yet supported (ARROW-14153)
+    # result = list(dataset_reader.to_batches(dataset, batch_size=2))
+    # assert len(result) == 2
+    # assert result[0].num_rows == 2
+    # assert result[0].equals(table.slice(0, 2).to_batches()[0])
+    # assert result[1].num_rows == 1
+    # assert result[1].equals(table.slice(2, 1).to_batches()[0])
+
+
+def test_orc_format_not_supported():
+    try:
+        from pyarrow.dataset import OrcFileFormat  # noqa
+    except ImportError:
+        # ORC is not available, test error message
+        with pytest.raises(
+            ValueError, match="not built with support for the ORC file"
+        ):
+            ds.dataset(".", format="orc")
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2393,6 +2393,14 @@ def test_orc_format(tempdir, dataset_reader):
     result.validate(full=True)
     assert result.equals(table.select(["b"]))
 
+    result = dataset_reader.to_table(
+        dataset, columns={"b2": ds.field("b") * 2}
+    )
+    result.validate(full=True)
+    assert result.equals(
+        pa.table({'b2': pa.array([.2, .4, .6], type="float64")})
+    )
+
     assert dataset_reader.count_rows(dataset) == 3
     assert dataset_reader.count_rows(dataset, filter=ds.field("a") > 2) == 1
 

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -180,3 +180,82 @@ def test_orcfile_readwrite():
     buffer_reader = pa.BufferReader(buffer_output_stream.getvalue())
     output_table = orc.ORCFile(buffer_reader).read()
     assert table.equals(output_table)
+
+
+def test_column_selection(tempdir):
+    from pyarrow import orc
+
+    # create a table with nested types
+    inner = pa.field('inner', pa.int64())
+    middle = pa.field('middle', pa.struct([inner]))
+    fields = [
+        pa.field('basic', pa.int32()),
+        pa.field(
+            'list', pa.list_(pa.field('item', pa.int32()))
+        ),
+        pa.field(
+            'struct', pa.struct([middle, pa.field('inner2', pa.int64())])
+        ),
+        pa.field(
+            'list-struct', pa.list_(pa.field(
+                'item', pa.struct([
+                    pa.field('inner1', pa.int64()),
+                    pa.field('inner2', pa.int64())
+                ])
+            ))
+        ),
+        pa.field('basic2', pa.int64()),
+    ]
+    arrs = [
+        [0], [[1, 2]], [{"middle": {"inner": 3}, "inner2": 4}],
+        [[{"inner1": 5, "inner2": 6}, {"inner1": 7, "inner2": 8}]], [9]]
+    table = pa.table(arrs, schema=pa.schema(fields))
+
+    path = str(tempdir / 'test.orc')
+    orc.write_table(table, path)
+    orc_file = orc.ORCFile(path)
+
+    # default selecting all columns
+    result1 = orc_file.read()
+    assert result1.equals(table)
+
+    # selecting with columns names
+    result2 = orc_file.read(columns=["basic", "basic2"])
+    assert result2.equals(table.select(["basic", "basic2"]))
+
+    result3 = orc_file.read(columns=["list", "struct", "basic2"])
+    assert result3.equals(table.select(["list", "struct", "basic2"]))
+
+    # using dotted paths
+    result4 = orc_file.read(columns=["struct.middle.inner"])
+    expected4 = pa.table({"struct": [{"middle": {"inner": 3}}]})
+    assert result4.equals(expected4)
+
+    result5 = orc_file.read(columns=["struct.inner2"])
+    expected5 = pa.table({"struct": [{"inner2": 4}]})
+    assert result5.equals(expected5)
+
+    result6 = orc_file.read(
+        columns=["list", "struct.middle.inner", "struct.inner2"]
+    )
+    assert result6.equals(table.select(["list", "struct"]))
+
+    result7 = orc_file.read(columns=["list-struct.inner1"])
+    expected7 = pa.table({"list-struct": [[{"inner1": 5}, {"inner1": 7}]]})
+    assert result7.equals(expected7)
+
+    # selecting with (Arrow-based) field indices
+    result2 = orc_file.read(columns=[0, 4])
+    assert result2.equals(table.select(["basic", "basic2"]))
+
+    result3 = orc_file.read(columns=[1, 2, 3])
+    assert result3.equals(table.select(["list", "struct", "list-struct"]))
+
+    # error on non-existing name or index
+    with pytest.raises(IOError):
+        # liborc returns ParseError, which gets translated into IOError
+        # instead of ValueError
+        orc_file.read(columns=["wrong"])
+
+    with pytest.raises(ValueError):
+        orc_file.read(columns=[5])

--- a/python/setup.py
+++ b/python/setup.py
@@ -197,6 +197,7 @@ class build_ext(_build_ext):
         '_cuda',
         '_flight',
         '_dataset',
+        '_dataset_orc',
         '_parquet',
         '_orc',
         '_plasma',
@@ -420,6 +421,10 @@ class build_ext(_build_ext):
         if name == '_hdfs' and not self.with_hdfs:
             return True
         if name == '_dataset' and not self.with_dataset:
+            return True
+        if name == '_dataset_orc' and not (
+                self.with_orc and self.with_dataset
+        ):
             return True
         if name == '_cuda' and not self.with_cuda:
             return True


### PR DESCRIPTION
Just BackPort : ARROW-13572: [C++][Datasets] Add ORC support to Datasets API [Upstream #10991].

Resolve two conflicting files:
```
python/pyarrow/includes/libarrow_dataset.pxd
python/setup.py

```
After resolve the conflicts,  refactor below classes to adapt Arrow 4.0 old interface again. Now compile successfully.

```
#       modified:   cpp/src/arrow/adapters/orc/adapter.cc
#       modified:   cpp/src/arrow/adapters/orc/adapter.h
#       modified:   cpp/src/arrow/dataset/expression.cc
#       modified:   cpp/src/arrow/dataset/expression.h
#       modified:   cpp/src/arrow/dataset/file_base.h
#       modified:   cpp/src/arrow/dataset/file_orc.cc
#       modified:   cpp/src/arrow/dataset/file_orc.h

```

Then BackPort ARROW-13797: [C++] Implement column projection pushdown to ORC reader in Datasets API [Upstream #11372] again and refactor some classes.
```
#       modified:   cpp/src/arrow/adapters/orc/adapter.cc
#       modified:   cpp/src/arrow/adapters/orc/adapter.h
#       modified:   cpp/src/arrow/dataset/file_orc.cc
#       modified:   cpp/src/arrow/dataset/file_orc_test.cc
#       modified:   python/pyarrow/tests/test_dataset.py
#       modified:   python/pyarrow/tests/test_orc.py

```

