### PR TITLE
Support no hyphen included date format  in castVARCHAR_date32_int64 and fix issue in unit test

### DIFF
--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -685,9 +685,17 @@ const char* castVARCHAR_date32_int64(gdv_int64 context, gdv_date32 in_day,
   const int char_buffer_length = kDateStringLen + 1;  // snprintf adds \0
   char char_buffer[char_buffer_length];
 
-  // yyyy-MM-dd hh:mm:ss.sss
-  int res = snprintf(char_buffer, char_buffer_length,
+  int res = -1;
+  if (length == 10) {
+    // yyyy-MM-dd hh:mm:ss.sss
+    res = snprintf(char_buffer, char_buffer_length,
                      "%04" PRId64 "-%02" PRId64 "-%02" PRId64, year, month, day);
+  } else if (length == 8) {
+    // yyyyMMdd
+    res = snprintf(char_buffer, char_buffer_length,
+                     "%04" PRId64 "%02" PRId64 "%02" PRId64, year, month, day);
+  }
+  
   if (res < 0) {
     gdv_fn_context_set_error_msg(context, "Could not format the date");
     return "";

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -687,7 +687,7 @@ const char* castVARCHAR_date32_int64(gdv_int64 context, gdv_date32 in_day,
 
   int res = -1;
   if (length == 10) {
-    // yyyy-MM-dd hh:mm:ss.sss
+    // yyyy-MM-dd
     res = snprintf(char_buffer, char_buffer_length,
                      "%04" PRId64 "-%02" PRId64 "-%02" PRId64, year, month, day);
   } else if (length == 8) {

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -749,11 +749,18 @@ TEST(TestTime, castVarcharDate) {
   gdv_int32 out_len;
   gdv_date64 date64 = castDATE_utf8(context_ptr, "2020-12-1", 9);
   gdv_date32 date32 = castDATE32_date64(date64);
+  // Test yyyy-MM-dd format
   const char* out = castVARCHAR_date32_int64(context_ptr, date32, 10L, &out_len);
   EXPECT_EQ(std::string(out, out_len), "2020-12-01");
-
+  // Test yyyyMMdd format
   out = castVARCHAR_date32_int64(context_ptr, date32, 8L, &out_len);
   EXPECT_EQ(std::string(out, out_len), "20201201");
+  
+  // Test date before unix epoch
+  date64 = castDATE_utf8(context_ptr, "1967-12-1", 9);
+  date32 = castDATE32_date64(date64);
+  out = castVARCHAR_date32_int64(context_ptr, date32, 10L, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "1967-12-01");
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -750,6 +750,9 @@ TEST(TestTime, castVarcharDate) {
   gdv_date32 date = castDATE_utf8(context_ptr, "1967-12-1", 9);
   const char* out = castVARCHAR_date32_int64(context_ptr, date, 10L, &out_len);
   EXPECT_EQ(std::string(out, out_len), "1967-12-01");
+
+  const char* out = castVARCHAR_date32_int64(context_ptr, date, 10L, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "19671201");
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -747,12 +747,13 @@ TEST(TestTime, castVarcharDate) {
   ExecutionContext context;
   int64_t context_ptr = reinterpret_cast<int64_t>(&context);
   gdv_int32 out_len;
-  gdv_date32 date = castDATE_utf8(context_ptr, "1967-12-1", 9);
-  const char* out = castVARCHAR_date32_int64(context_ptr, date, 10L, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "1967-12-01");
+  gdv_date64 date64 = castDATE_utf8(context_ptr, "2020-12-1", 9);
+  gdv_date32 date32 = castDATE32_date64(date64);
+  const char* out = castVARCHAR_date32_int64(context_ptr, date32, 10L, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "2020-12-01");
 
-  const char* out = castVARCHAR_date32_int64(context_ptr, date, 10L, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "19671201");
+  out = castVARCHAR_date32_int64(context_ptr, date32, 8L, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "20201201");
 }
 
 }  // namespace gandiva


### PR DESCRIPTION
This patch is proposed to quickly support date format with no hyphen for from_unixtime expression, etc.