### PR TITLE
Add a castTIMESTAMP function with date format checked to exclude unsupported cases

### DIFF
--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -57,6 +57,10 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
                      kResultNullIfNull, "castTIMESTAMP_utf8",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
+      NativeFunction("castTIMESTAMP_with_validation_check", {}, DataTypeVector{utf8()}, timestamp(),
+                     kResultNullInternal, "castTIMESTAMP_with_validation_check_utf8",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
+
       NativeFunction("castTIMESTAMP_withCarrying", {}, DataTypeVector{utf8()}, timestamp(),
                      kResultNullInternal, "castTIMESTAMP_withCarrying_utf8",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -858,6 +858,23 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t context, const char* input, gdv_int32 l
   return std::chrono::time_point_cast<milliseconds>(date_time).time_since_epoch().count();
 }
 
+gdv_timestamp castTIMESTAMP_with_validation_check_utf8(int64_t context, const char* input,
+                                                       gdv_int32 length, bool in_valid,
+                                                       bool* out_valid) {
+  if (!in_valid) {
+    *out_valid = false;
+    return 0;
+  }
+  // Suppose the input is yyyy-MM-dd.
+  // TODO: check validaition during/after parsing.
+  if (length > 10) {
+    *out_valid = false;
+    return 0;
+  }
+  return castTIMESTAMP_withCarrying_utf8(context, input, length, in_valid, out_valid);
+}
+
+
 /*
  * Input consists of mandatory and optional fields.
  * Mandatory fields are year, month and day.

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -279,6 +279,9 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t execution_context, const char* input,
 gdv_timestamp castTIMESTAMP_withCarrying_utf8(int64_t context, const char* input,
                                               gdv_int32 length, bool in_valid,
                                               bool* out_valid);
+gdv_timestamp castTIMESTAMP_with_validation_check_utf8(int64_t context, const char* input,
+                                              gdv_int32 length, bool in_valid,
+                                              bool* out_valid);
 gdv_timestamp castTIMESTAMP_date64(gdv_date64);
 gdv_timestamp castTIMESTAMP_int64(gdv_int64);
 gdv_date64 castDATE_timestamp(gdv_timestamp);


### PR DESCRIPTION
This patch is depended by https://github.com/oap-project/gazelle_plugin/pull/622, which is already merged into gazelle. I forgot to submit this PR.