### PR TITLE
Get spark-compatible result from locate function if empty substring is given

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1327,9 +1327,9 @@ gdv_int32 locate_utf8_utf8_int32(gdv_int64 context, const char* sub_str,
     gdv_fn_context_set_error_msg(context, "Start position must be greater than 0");
     return 0;
   }
-
-  if (str_len == 0 || sub_str_len == 0) {
-    return 0;
+  // TO align with vanilla spark.
+  if (sub_str_len == 0) {
+    return 1;
   }
 
   gdv_int32 byte_pos = utf8_byte_pos(context, str, str_len, start_pos - 1);

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -921,7 +921,11 @@ TEST(TestStringOps, TestLocate) {
   EXPECT_FALSE(ctx.has_error());
 
   pos = locate_utf8_utf8_int32(ctx_ptr, "", 0, "str", 3, 1);
-  EXPECT_EQ(pos, 0);
+  EXPECT_EQ(pos, 1);
+  EXPECT_FALSE(ctx.has_error());
+
+  pos = locate_utf8_utf8_int32(ctx_ptr, "", 0, "", 0, 1);
+  EXPECT_EQ(pos, 1);
   EXPECT_FALSE(ctx.has_error());
 
   pos = locate_utf8_utf8_int32(ctx_ptr, "bar", 3, "barbar", 6, 0);


### PR DESCRIPTION
For the purpose of aligning with vanilla spark.