### PR TITLE
Pass partition ID to rand expression for achieving genuine random distribution globally

### DIFF
--- a/cpp/src/gandiva/function_registry_math_ops.cc
+++ b/cpp/src/gandiva/function_registry_math_ops.cc
@@ -98,6 +98,9 @@ std::vector<NativeFunction> GetMathOpsFunctionRegistry() {
                      NativeFunction::kNeedsFunctionHolder),
       NativeFunction("random", {"rand"}, DataTypeVector{int64()}, float64(),
                      kResultNullNever, "gdv_fn_random_with_seed64",
+                     NativeFunction::kNeedsFunctionHolder),
+      NativeFunction("random", {"rand"}, DataTypeVector{int64(), int32()}, float64(),
+                     kResultNullNever, "gdv_fn_random_with_seed64_offset",
                      NativeFunction::kNeedsFunctionHolder)};
 
   return math_fn_registry_;

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -118,6 +118,13 @@ double gdv_fn_random_with_seed64(int64_t ptr, int64_t seed, bool seed_validity) 
   return (*holder)();
 }
 
+double gdv_fn_random_with_seed64_offset(int64_t ptr, int64_t seed, bool seed_validity, 
+                                        int32_t offset, bool offset_validity) {
+  gandiva::RandomGeneratorHolder* holder =
+      reinterpret_cast<gandiva::RandomGeneratorHolder*>(ptr);
+  return (*holder)(); 
+}
+
 int64_t gdv_fn_to_date_utf8_utf8(int64_t context_ptr, int64_t holder_ptr,
                                  const char* data, int data_len, bool in1_validity,
                                  const char* pattern, int pattern_len, bool in2_validity,

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -89,6 +89,9 @@ double gdv_fn_random_with_seed(int64_t ptr, int32_t seed, bool seed_validity);
 
 double gdv_fn_random_with_seed64(int64_t ptr, int64_t seed, bool seed_validity);
 
+double gdv_fn_random_with_seed64_offset(int64_t ptr, int64_t seed, bool seed_validity, 
+                                        int32_t offset, bool offset_validity);
+
 GANDIVA_EXPORT
 const char* gdv_fn_sha256_decimal128(int64_t context, int64_t x_high, uint64_t x_low,
                                      int32_t x_precision, int32_t x_scale,

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -186,7 +186,10 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
   // Instantiate the projector with the completely built llvm generator
   *projector = std::shared_ptr<Projector>(
       new Projector(std::move(llvm_gen), schema, output_fields, configuration));
-  cache.PutModule(cache_key, *projector);
+  // For statful projection, we should not cache it.
+  if (cache_key.ToString().find(" rand(") == std::string::npos) {
+    cache.PutModule(cache_key, *projector);
+  }
 
   return Status::OK();
 }

--- a/cpp/src/gandiva/random_generator_holder.cc
+++ b/cpp/src/gandiva/random_generator_holder.cc
@@ -17,6 +17,17 @@
 
 #include "gandiva/random_generator_holder.h"
 #include "gandiva/node.h"
+#include "gandiva/projector.h"
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
+#include "gandiva/tree_expr_builder.h"
+//#include "gandiva/tests/test_util.h"
+#include "arrow/type_traits.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/array/builder_base.h"
+#include <type_traits>
+
 
 namespace gandiva {
 Status RandomGeneratorHolder::Make(const FunctionNode& node,
@@ -30,28 +41,67 @@ Status RandomGeneratorHolder::Make(const FunctionNode& node,
   }
 
   auto literal = dynamic_cast<LiteralNode*>(node.children().at(0).get());
-  ARROW_RETURN_IF(literal == nullptr,
-                  Status::Invalid("'random' function requires a literal as parameter"));
-
-  auto literal_type = literal->return_type()->id();
-  ARROW_RETURN_IF(
+  //ARROW_RETURN_IF(literal == nullptr,
+  //                Status::Invalid("'random' function requires a literal as parameter"));
+  int64_t seed;
+  if (literal != nullptr) {
+    auto literal_type = literal->return_type()->id();
+    ARROW_RETURN_IF(
       literal_type != arrow::Type::INT32 && literal_type != arrow::Type::INT64,
       Status::Invalid("'random' function requires an int32/int64 literal as parameter"));
-
+    if (literal_type == arrow::Type::INT32) {
+      seed = literal->is_null() ? 0 : arrow::util::get<int32_t>(literal->holder());
+    } else {
+      seed = literal->is_null() ? 0 : arrow::util::get<int64_t>(literal->holder());
+    }
+  } else {
+    auto first_children_node_ptr = node.children().at(0);
+    //auto schema = arrow::schema({});
+    auto f0 = arrow::field("f0", arrow::float64());
+    auto schema = arrow::schema({f0});
+    std::shared_ptr<Projector> projector;
+    // Not actually used.
+    auto res = field("res", arrow::int32());
+    auto expr = TreeExprBuilder::MakeExpression(first_children_node_ptr, res);
+    auto builder = ConfigurationBuilder();
+    auto config = builder.DefaultConfiguration();
+    auto status = Projector::Make(schema, {expr}, config, &projector);
+    arrow::ArrayVector outputs;
+    arrow::MemoryPool* pool = arrow::default_memory_pool();
+    
+    //arrow::ArrayVector inputs;
+    //auto in_batch = arrow::RecordBatch::Make(schema, 0, inputs);
+    
+    std::vector<int> input0 = {16, 10, -14, 8};
+    std::vector<bool> validity = {true, true, true, true};
+    std::shared_ptr<arrow::Array> array0;
+    //arrow::ArrayFromVector<arrow::DoubleType, double>(validity, values, &array0);
+    //auto array0 = MakeArrowArray<arrow::DoubleType, double>(input0, validity);
+    
+    auto type = arrow::TypeTraits<arrow::Int32Type>::type_singleton();
+    std::unique_ptr<arrow::ArrayBuilder> builder_ptr;
+    MakeBuilder(pool, type, &builder_ptr);
+    auto& arrow_array_builder = dynamic_cast<typename arrow::TypeTraits<arrow::Int32Type>::BuilderType&>(*builder_ptr);
+    for (size_t i = 0; i < input0.size(); ++i) {
+      arrow_array_builder.Append(input0[i]);
+    }
+    arrow_array_builder.Finish(&array0);   
+ 
+    auto in_batch = arrow::RecordBatch::Make(schema, 4, {array0});
+   
+    //arrow::RecordBatch in_batch;
+    projector->Evaluate(*in_batch, pool, &outputs);
+    auto result_arr = std::dynamic_pointer_cast<arrow::Int32Array>(outputs.at(0));
+    //seed = dynamic_cast<int32_t>(result_arr->Value(0));
+    seed = result_arr->Value(0);
+  }
   // The offset is a partition ID in spark SQL. It is used to achieve genuine random distribution globally.
   int32_t offset = 0;
   if (node.children().size() > 1) {
     auto offset_node = dynamic_cast<LiteralNode*>(node.children().at(1).get());
     offset = offset_node->is_null() ? 0 : arrow::util::get<int32_t>(offset_node->holder());
   }
-  if (literal_type == arrow::Type::INT32) {
-    int32_t seed = literal->is_null() ? 0 : arrow::util::get<int32_t>(literal->holder());
-    *holder = std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder(seed + offset));
-  } else {
-    int64_t seed = literal->is_null() ? 0 : arrow::util::get<int64_t>(literal->holder());
-    *holder = std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder(
-      seed + static_cast<int64_t>(offset)));
-  }
+  *holder = std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder(seed + offset));
   return Status::OK();
 }
 }  // namespace gandiva


### PR DESCRIPTION
In this patch, projection with "rand" is removed from the cache, since "rand(seed)" is stateful. This change need to be discussed.