### PR TITLE
Handle the case of comparing NAN and infinity

### DIFF
--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -147,6 +147,8 @@ NUMERIC_DATE_TYPES(BINARY_RELATIONAL, greater_than_or_equal_to, >=)
 #undef BINARY_RELATIONAL
 
 // Relational binary fns : left, right params are same, return is bool.
+// To algin with spark, NAN is treated as infinity. The exception case
+// is that the other is infinity.
 #define BINARY_RELATIONAL_NAN(NAME, TYPE, OP)                       \
   FORCE_INLINE                                                      \
   bool NAME##_##TYPE##_##TYPE(gdv_##TYPE left, gdv_##TYPE right) {  \
@@ -156,8 +158,14 @@ NUMERIC_DATE_TYPES(BINARY_RELATIONAL, greater_than_or_equal_to, >=)
     if (left_is_nan && right_is_nan) {                              \
       return infinity OP infinity;                                  \
     } else if (left_is_nan) {                                       \
+      if (isinf(right)) {                                           \
+        return NAN OP right;                                        \
+      }                                                             \
       return infinity OP right;                                     \
     } else if (right_is_nan) {                                      \
+      if (isinf(left)) {                                            \
+        return left OP NAN;                                         \
+      }                                                             \
       return left OP infinity;                                      \
     }                                                               \
     return left OP right;                                           \

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -86,6 +86,13 @@ TEST(TestArithmeticOps, TestPMod) {
   EXPECT_EQ(out_valid, false);
 }
 
+TEST(TestArithmeticOps, TestCompare) {
+  EXPECT_EQ(equal_with_nan_float32_float32(NAN, 1.0/0.0), false);
+  EXPECT_EQ(equal_with_nan_float32_float32(1.0/0.0, NAN), false);
+  EXPECT_EQ(not_equal_with_nan_float32_float32(NAN, 1.0/0.0), true);
+  EXPECT_EQ(not_equal_with_nan_float32_float32(1.0/0.0, NAN), true);
+}
+
 TEST(TestArithmeticOps, TestDivide) {
   gandiva::ExecutionContext context;
   EXPECT_EQ(divide_int64_int64(reinterpret_cast<gdv_int64>(&context), 10, 0), 0);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -154,6 +154,9 @@ gdv_int64 pmod_int64_int64(gdv_int64 in1, bool in1_valid, gdv_int64 in2, bool in
 gdv_float32 pmod_float32_float32(gdv_float32 in1, bool in1_valid, gdv_float32 in2, bool in2_valid, bool* out_valid);
 gdv_float64 pmod_float64_float64(gdv_float64 in1, bool in1_valid, gdv_float64 in2, bool in2_valid, bool* out_valid);
 
+bool equal_with_nan_float32_float32(gdv_float32 in1, gdv_float32 in2);
+bool not_equal_with_nan_float32_float32(gdv_float32 in1, gdv_float32 in2);
+
 gdv_int64 divide_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);
 
 gdv_int64 div_int64_int64(gdv_int64 context, gdv_int64 in1, gdv_int64 in2);


### PR DESCRIPTION
We previously use infinity to replace NAN for comparison to align with Spark's behavior. But the exception is comparing NAN and infinity. So this PR adds some checks for such case.