### PR TITLE
allow read parquet with invalid utf8 data

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -415,7 +415,8 @@ Status TransferBinary(RecordReader* reader, MemoryPool* pool,
   }
   ::arrow::compute::ExecContext ctx(pool);
   ::arrow::compute::CastOptions cast_options;
-  cast_options.allow_invalid_utf8 = false;  // avoid spending time validating UTF8 data
+  // keep the behavior consistent with spark
+  cast_options.allow_invalid_utf8 = true;
 
   auto binary_reader = dynamic_cast<BinaryRecordReader*>(reader);
   DCHECK(binary_reader);


### PR DESCRIPTION
We meet `Invalid UTF8 payload` while reading parquet with some gbk data in it. However, Spark won't throw any Exception when it happens, and just returns garbled data. Thus in this PR, we are trying to ignore the utf8 check while reading data.