### PR TITLE
parse_url support invalid charactor in query

### DIFF
--- a/cpp/src/gandiva/parse_url_holder.h
+++ b/cpp/src/gandiva/parse_url_holder.h
@@ -44,29 +44,27 @@ namespace gandiva {
     const char * operator()(
         ExecutionContext *ctx, const char * url, int32_t url_len,
         const char * part, int32_t part_len, int32_t *out_length) {
-      std::string url_string(url, url_len);
       std::string part_string(part, part_len);
       arrow::internal::Uri uri;
       std::string out;
 
       // Here we skip the query parsing, as urlparser does not support invalid characters in url,
-      // which is actually supported in vanilla Spark.
-      std::string::size_type start_query_position = url_string.find_first_of("?");
-      std::string query_string;
-      if (start_query_position != url_string.npos) {
-        std::string::size_type end_query_position = url_string.find_last_of("#");
-        if (end_query_position != url_string.npos) {
-          query_string =
-              url_string.substr(start_query_position + 1, end_query_position - start_query_position -1);
-          url_string = url_string.replace(
-              start_query_position + 1, end_query_position - start_query_position - 1, "query=query");
-        } else {
-          query_string =
-              url_string.substr(start_query_position + 1, url_len - start_query_position -1);
-          url_string = url_string.replace(
-              start_query_position + 1, url_len - start_query_position - 1, "query=query");
+      // which are actually supported in vanilla Spark, except spaces.
+      int32_t query_start_idx = -1;
+      int32_t fragment_start_idx = -1;
+      for (int32_t idx = url_len - 1; idx >= 0; idx--) {
+        // consist with vanilla spark
+        if (url[idx] == ' ') {
+          return nullptr;
+        } else if (url[idx] == '?') {
+          query_start_idx = idx;
+          break;
+        } else if (url[idx] == '#') {
+          fragment_start_idx = idx;
         }
       }
+      int32_t part_url_len = query_start_idx == -1 ? url_len : query_start_idx + 1;
+      std::string url_string(url, part_url_len);
       auto status = uri.Parse(url_string);
       if (!status.ok()) {
         return nullptr;
@@ -78,16 +76,28 @@ namespace gandiva {
         out = uri.path();
       } else if (part_string == "QUERY") {
         // consistent with vanilla spark
-        if (uri.has_query()) {
-          out = query_string;
+        if (query_start_idx != -1) {
+          if (fragment_start_idx != -1) {
+            std::string query_string(url + query_start_idx + 1, fragment_start_idx - query_start_idx - 1);
+            out = query_string;
+          } else {
+            std::string query_string(url + query_start_idx + 1, url_len - query_start_idx - 1);
+            out = query_string;
+          }
         }  else {
           return nullptr;
         }
       } else if (part_string == "PROTOCOL") {
         out = uri.scheme();
       } else if (part_string == "FILE") {
-        if (uri.has_query()) {
-          out = uri.path() + "?" + query_string;
+        if (query_start_idx != -1) {
+          if (fragment_start_idx != -1) {
+            std::string query_string(url + query_start_idx + 1, fragment_start_idx - query_start_idx - 1);
+            out = uri.path() + "?" + query_string;
+          } else {
+            std::string query_string(url + query_start_idx + 1, url_len - query_start_idx - 1);
+            out = uri.path() + "?" + query_string;
+          }
         } else {
           out = uri.path();
         }
@@ -104,8 +114,9 @@ namespace gandiva {
         out = uri.user_info();
       } else if (part_string == "REF") {
         // consistent with vanilla spark
-        if (uri.has_fragment()) {
-          out = uri.fragment();
+        if (fragment_start_idx != -1) {
+          std::string fragment_string(url + fragment_start_idx + 1, url_len - fragment_start_idx -1);
+          out = fragment_string;
         } else {
           return nullptr;
         }
@@ -129,63 +140,61 @@ namespace gandiva {
         ExecutionContext *ctx, const char * url, int32_t url_len,
         const char * part, int32_t part_len,
         const char * pattern, int32_t pattern_len, int32_t *out_length) {
-      std::string url_string(url, url_len);
       std::string part_string(part, part_len);
       std::string pattern_string(pattern, pattern_len);
       arrow::internal::Uri uri;
       std::string out;
 
-      // Here we skip the query parsing, as urlparser does not support invalid character in url,
-      // which is actually supported in vanilla Spark.
-      std::string::size_type start_query_position = url_string.find_first_of("?");
-      std::string query_string;
-      if (start_query_position != url_string.npos) {
-        std::string::size_type end_query_position = url_string.find_last_of("#");
-        if (end_query_position != url_string.npos) {
-          query_string =
-              url_string.substr(start_query_position + 1, end_query_position - start_query_position -1);
-          url_string = url_string.replace(
-              start_query_position + 1, end_query_position - start_query_position - 1, "query=query");
-        } else {
-          query_string =
-              url_string.substr(start_query_position + 1, url_len - start_query_position -1);
-          url_string = url_string.replace(
-              start_query_position + 1, url_len - start_query_position - 1, "query=query");
+      if (part_string != "QUERY") {
+        return nullptr;
+      }
+
+      // Here we skip the query parsing, as urlparser does not support invalid characters in url,
+      // which are actually supported in vanilla Spark, except spaces.
+      int query_start_idx = -1;
+      for (int idx = url_len - 1; idx >= 0; idx--) {
+        if (url[idx] == ' ') {
+          return nullptr;
+        } else if (url[idx] == '?') {
+          query_start_idx = idx;
+          break;
         }
       }
+      if (query_start_idx == -1) {
+        return nullptr;
+      }
+
+      std::string url_string(url, query_start_idx + 1);
       auto status = uri.Parse(url_string);
       if (!status.ok()) {
         return nullptr;
       }
 
-      if (part_string != "QUERY" || !uri.has_query()) {
-        return nullptr;
-      } else {
-        RE2 re2("(&|^)" + pattern_string + "=([^&]*)");
-        int groups_num = re2.NumberOfCapturingGroups();
-        RE2::Arg *args[groups_num];
-        for (int i = 0; i < groups_num; i++) {
-          args[i] = new RE2::Arg;
-        }
-        *(args[1]) = &out;
-        // Use re2 instead of pattern_ for better performance.
-        bool matched = RE2::PartialMatchN(query_string, re2, args, groups_num);
-        if (!matched) {
-          *out_length = 0;
-          return nullptr;
-        }
-
-        *out_length = static_cast<int32_t>(out.length());
-        char *result_buffer = reinterpret_cast<char *>(ctx->arena()->Allocate(*out_length));
-        if (result_buffer == NULLPTR) {
-          ctx->set_error_msg("Could not allocate memory for result! Wrong result may be returned!");
-          *out_length = 0;
-          return nullptr;
-        }
-        memcpy(result_buffer, out.data(), *out_length);
-
-        return result_buffer;
+      std::string query_string(url + query_start_idx + 1, url_len - query_start_idx - 1);
+      RE2 re2("(&|^)" + pattern_string + "=([^&|^#]*)");
+      int groups_num = re2.NumberOfCapturingGroups();
+      RE2::Arg *args[groups_num];
+      for (int i = 0; i < groups_num; i++) {
+        args[i] = new RE2::Arg;
       }
+      *(args[1]) = &out;
+      // Use re2 instead of pattern_ for better performance.
+      bool matched = RE2::PartialMatchN(query_string, re2, args, groups_num);
+      if (!matched) {
+        *out_length = 0;
+        return nullptr;
+      }
+
+      *out_length = static_cast<int32_t>(out.length());
+      char *result_buffer = reinterpret_cast<char *>(ctx->arena()->Allocate(*out_length));
+      if (result_buffer == NULLPTR) {
+        ctx->set_error_msg("Could not allocate memory for result! Wrong result may be returned!");
+        *out_length = 0;
+        return nullptr;
+      }
+      memcpy(result_buffer, out.data(), *out_length);
+
+      return result_buffer;
     }
   };  // namespace gandiva
 }

--- a/cpp/src/gandiva/parse_url_holder_test.cc
+++ b/cpp/src/gandiva/parse_url_holder_test.cc
@@ -140,6 +140,7 @@ namespace gandiva {
 
     // Special url
     input_string = "/?a=abc";
+    part_string = "QUERY";
     const char *ret11 = parse_url(
         &execution_context_, input_string.c_str(), static_cast<int32_t>(input_string.length()),
         part_string.c_str(), static_cast<int32_t>(part_string.length()), &out_length);
@@ -195,7 +196,7 @@ namespace gandiva {
     EXPECT_EQ(ret3, nullptr);
 
     // Special url
-    input_string = "/?a=abc";
+    input_string = "/?c=测试&a=abc";
     query_string = "a";
     const char *ret4 = parse_url(
         &execution_context_, input_string.c_str(), static_cast<int32_t>(input_string.length()),


### PR DESCRIPTION
Vanilla Spark supports parsing urls with invalid charactors, but urlparser, which used by parse_url, only supports RC3837 URLs. This pr try to skip query parsing to avoid the exception when there are invalid charactors in url.