### PR TITLE
fix read parquet with null check

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -186,7 +186,8 @@ static util::optional<Expression> ColumnChunkStatisticsAsExpression(
   auto field_expr = field_ref(field->name());
 
   // Optimize for corner case where all values are nulls
-  if (statistics->num_values() == statistics->null_count()) {
+  // num_values is the count of the non-null values, thus we can check num_values only.
+  if (statistics->num_values() == 0) {
     return equal(std::move(field_expr), literal(MakeNullScalar(field->type())));
   }
 


### PR DESCRIPTION
We meet the problem when we are trying to read a parquet file which has 20 non-null values and 20 null values in one RowGroup. The program will skip the RowGroup if all nulls. However,  `statistics->num_values()` acutally represents the count of the non-null values, and we won't read this RowGroup with `isnotnull` pushed down.
Related Patch: https://github.com/apache/arrow/commit/8b4942728e7347dc921a2d423e996fea5f9e2102#diff-c49cc60c1aa3a00a84b72c89ce2c8f5eb5d034ed8383741def1c4ae377d62854R189