### PR TITLE
Add fast_float to the include dir

### DIFF
--- a/cpp/src/arrow/vendored/fast_float/CMakeLists.txt
+++ b/cpp/src/arrow/vendored/fast_float/CMakeLists.txt
@@ -15,8 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow_install_all_headers("arrow/vendored")
-
-add_subdirectory(datetime)
-add_subdirectory(fast_float)
-add_subdirectory(double-conversion)
+arrow_install_all_headers("arrow/vendored/fast_float")

--- a/cpp/src/arrow/vendored/fast_float/ascii_number.h
+++ b/cpp/src/arrow/vendored/fast_float/ascii_number.h
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "float_common.h"
+#include "fast_float.h"
 
 namespace arrow_vendored {
 namespace fast_float {


### PR DESCRIPTION
If we want use fast_float in sub libraries, such as gazelle, we need add it to the include dir.