### PR TITLE
Parse int96 to milliseconds

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -377,7 +377,9 @@ Status TransferInt96(RecordReader* reader, MemoryPool* pool,
       // isn't representable as a 64-bit Unix timestamp.
       *data_ptr++ = 0;
     } else {
-      *data_ptr++ = Int96GetNanoSeconds(values[i]);
+      // Keep the behavior with vanilla spark.
+      // Vanilla spark would parse int96 to micro second.
+      *data_ptr++ = Int96GetNanoSeconds(values[i]) / 1000;
     }
   }
   *out = std::make_shared<TimestampArray>(type, length, std::move(data),


### PR DESCRIPTION
We need to keep the behavior with vanilla spark when parsing timestamp data when data is stored as int94.
The related issue: [NSE-1171](https://github.com/oap-project/gazelle_plugin/issues/1171)
The related spark suite: `Migration from INT96 to TIMESTAMP_MICROS timestamp type`