### PR TITLE
Fix: conv return null with invalid string

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1906,8 +1906,9 @@ const char* conv(gdv_int64 context, const char* input, gdv_int32 input_len, bool
   }
   *out_len = 64 - i - 1;
   if (*out_len == 0) {
-    *out_valid = false;
-    return "";
+    *out_len = 1;
+    *out_valid = true;
+    return "0";
   }
 
   *out_valid = true;

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1430,6 +1430,20 @@ TEST(TestStringOps, TestConv) {
   EXPECT_EQ(out_valid, true);
   EXPECT_EQ(out_len, 1);
   EXPECT_EQ(std::string(out_str, out_len), "0");
+
+  // invalid str as input.
+  out_str = conv(ctx_ptr, "this is a test", 14, true, 10, true, 16, true, &out_valid, &out_len);
+  EXPECT_EQ(out_valid, true);
+  EXPECT_EQ(out_len, 1);
+  EXPECT_EQ(std::string(out_str, out_len), "0");
+  out_str = conv(ctx_ptr, "-", 1, true, 10, true, 16, true, &out_valid, &out_len);
+  EXPECT_EQ(out_valid, true);
+  EXPECT_EQ(out_len, 1);
+  EXPECT_EQ(std::string(out_str, out_len), "0");
+  out_str = conv(ctx_ptr, "+", 1, true, 10, true, 16, true, &out_valid, &out_len);
+  EXPECT_EQ(out_valid, true);
+  EXPECT_EQ(out_len, 1);
+  EXPECT_EQ(std::string(out_str, out_len), "0");
 }
 
 TEST(TestStringOps, TestConvPerf) {


### PR DESCRIPTION
Conv should return '0' when parsing invalid string as input, not null.